### PR TITLE
Allow Tasks to be filtered by base repo branch.

### DIFF
--- a/lib/taskcluster-config.js
+++ b/lib/taskcluster-config.js
@@ -113,7 +113,9 @@ taskclusterConfig.processConfig = function(params) {
         // Filter out tasks that aren't associated with the current event
         // being handled
         let events = taskConfig.task.extra.github.events;
+        let branches = taskConfig.task.extra.github.branches;
         if (!utils.listContainsExpressions(events, [payload.details['event.type']])) return false;
+        if (branches && !utils.listContainsExpressions(branches, [payload.details['event.base.repo.branch']])) return false;
         return true;
       });
       accept(completeTaskGraphConfig(taskclusterConfig, payload));

--- a/test/data/configs/taskcluster.branchlimited.yml
+++ b/test/data/configs/taskcluster.branchlimited.yml
@@ -1,0 +1,25 @@
+version: 0
+metadata:
+  name: "name"
+  description: "description"
+  owner: "test@test.com"
+  source: "http://mrrrgn.com"
+tasks:
+  - provisionerId: aprovisioner
+    workerType: worker
+    extra:
+      github:
+        env: true
+        events:
+          - push
+        branches:
+          - master
+    payload:
+      image: "ubuntu:latest"
+      command:
+        - test
+    metadata:
+      name: "name"
+      description: "description"
+      owner: "test@test.com"
+      source: "http://mrrrgn.com"

--- a/test/taskcluster_config_test.js
+++ b/test/taskcluster_config_test.js
@@ -120,4 +120,26 @@ suite('TaskCluster-Github Config', () => {
       'tasks[0].task.payload.command': ['test'],
       'tasks[0].task.extra.github.events': ['pull_request.opened', 'pull_request.synchronize', 'pull_request.reopened'],
     });
+
+  buildConfigTest(
+    'Pull Event, Single Task Config, Branch Limited (on branch)',
+    configPath + 'taskcluster.branchlimited.yml',
+    {
+      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
+    },
+    {
+      'tasks[0].task.extra.github.events': ['push'],
+      'tasks[0].task.extra.github.branches': ['master'],
+      'metadata.owner': 'test@test.com'
+    });
+
+  buildConfigTest(
+    'Pull Event, Single Task Config, Branch Limited (off branch)',
+    configPath + 'taskcluster.branchlimited.yml',
+    {
+      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'foobar'}}),
+    },
+    {
+      'tasks': []
+    });
 });


### PR DESCRIPTION
I've been working on using Taskcluster to push production-ready Docker images to Dockerhub. The way this works is that upon pushes to https://github.com/mozilla/balrog, we built and push images. In order to get the secrets needed to do so, I need to give that task the "secrets:get:repo:github.com/mozilla/balrog:dockerhub" scope. This works fine, except that scope is only available to repo:github.com/mozilla/balrog:branch:master, because we don't want pull requests or other potential branches in that repo to build production images.

This patch adds the ability to filter tasks on the base repo's branch, which supports my use case and I think is generally pretty useful.

I'm not a JS dev by any means, but this appears to work - my second test failed prior to my change to taskcluster-config.js.
