### PR TITLE
Set correct repo scope for pushes.

### DIFF
--- a/lib/taskcluster-config.js
+++ b/lib/taskcluster-config.js
@@ -34,9 +34,16 @@ function genGitHubEnvs(payload) {
  * it becomes a complete task graph config.
  **/
 function completeTaskGraphConfig(taskclusterConfig, payload) {
-  taskclusterConfig.scopes = [
-    `assume:repo:github.com/${ payload.organization }/${ payload.repository }:pull-request`
-  ];
+  if (payload.details['event.type'].startsWith('pull_request')) {
+    taskclusterConfig.scopes = [
+      `assume:repo:github.com/${ payload.organization }/${ payload.repository }:pull-request`
+    ];
+  }
+  else if (payload.details['event.type'] == 'push') {
+    taskclusterConfig.scopes = [
+      `assume:repo:github.com/${ payload.organization }/${ payload.repository }:branch:` + payload.details['event.base.repo.branch']
+    ];
+  }
 
   taskclusterConfig.routes = [
     `taskcluster-github.${ payload.organization }.${ payload.repository }.` + payload.details['event.head.sha']

--- a/test/taskcluster_config_test.js
+++ b/test/taskcluster_config_test.js
@@ -19,7 +19,7 @@ suite('TaskCluster-Github Config', () => {
         'event.type': 'pull_request.opened',
         'event.base.user.login': 'eventData.pull_request.base.user.login',
         'event.base.repo.url': 'eventData.pull_request.base.repo.clone_url',
-        'event.base.repo.branch': 'eventData.pull_request.base.default_branch',
+        'event.base.repo.branch': 'default_branch',
         'event.base.sha': 'eventData.pull_request.base.sha',
         'event.base.ref': 'eventData.pull_request.base.ref',
         'event.head.user.login': 'eventData.pull_request.head.user.login',
@@ -94,7 +94,8 @@ suite('TaskCluster-Github Config', () => {
     },
     {
       'tasks[0].task.extra.github.events': ['push'],
-      'metadata.owner': 'test@test.com'
+      'metadata.owner': 'test@test.com',
+      'scopes': ['assume:repo:github.com/testorg/testrepo:branch:default_branch'],
     });
 
   buildConfigTest(
@@ -106,7 +107,8 @@ suite('TaskCluster-Github Config', () => {
     {
       'metadata.owner': 'test@test.com',
       'tasks[0].task.payload.command': ['test'],
-      'tasks[0].task.extra.github.events': ['push']
+      'tasks[0].task.extra.github.events': ['push'],
+      'scopes': ['assume:repo:github.com/testorg/testrepo:branch:default_branch'],
     });
 
   buildConfigTest(
@@ -119,6 +121,7 @@ suite('TaskCluster-Github Config', () => {
       'metadata.owner': 'test@test.com',
       'tasks[0].task.payload.command': ['test'],
       'tasks[0].task.extra.github.events': ['pull_request.opened', 'pull_request.synchronize', 'pull_request.reopened'],
+      'scopes': ['assume:repo:github.com/testorg/testrepo:pull-request'],
     });
 
   buildConfigTest(
@@ -130,7 +133,8 @@ suite('TaskCluster-Github Config', () => {
     {
       'tasks[0].task.extra.github.events': ['push'],
       'tasks[0].task.extra.github.branches': ['master'],
-      'metadata.owner': 'test@test.com'
+      'metadata.owner': 'test@test.com',
+      'scopes': ['assume:repo:github.com/testorg/testrepo:branch:master'],
     });
 
   buildConfigTest(


### PR DESCRIPTION
I thought this was happening already, but apparently it's not! Currently, we grant assume:repo:...:pull-request even for pushes.
