### PR TITLE
Removed empty list of scopes, to fix formatting of docs site

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -73,7 +73,6 @@ api.declare({
   method:     'post',
   route:      '/github',
   name:       'githubWebHookConsumer',
-  scopes:     [[]],
   title:      "Consume GitHub WebHook",
   stability:  'experimental',
   description: [


### PR DESCRIPTION
Note, scopes are not a required property; see [api reference schema](https://github.com/taskcluster/taskcluster-lib-api/blob/e2e36c706663d041af815081072c97d0fa214509/src/schemas/api-reference.json#L120-L123).

Having an empty list of scopes strangely messes up the formatting of the **Consume GitHub WebHook** section of the [API docs](http://docs.taskcluster.net/services/taskcluster-github/).

Removing the scopes solves this problem, as can be seen by the **Ping Server** API endpoint in the same web page.

Note, this is probably a rendering bug in firefox, since the html seems correct, even with no scopes listed:

``` html
  <dl class="dl-horizontal method-properties">
    <dt>Method</dt>
    <dd><div class="label label-default">post</div></dd>
    <dt>Route</dt>
    <dd><code>/github</code></dd>

    <dt>Scopes</dt>
      <dd>

      </dd>

    <dt>Signature</dt>

    <dd><code>githubWebHookConsumer() : void</code></dd>
  </dl>
```

However, in my browser, at least, it renders badly...

![Screenshot of badly rendered content](http://people.mozilla.org/~pmoore/Screen%20Shot%202016-04-01%20at%2015.20.26.png)

So even though this might ultimately be a rendering bug in firefox, I'd still prefer to fix it by removing the empty definition, also to be consistent with e.g. **Ping Server**.
