### PR TITLE
Stop commenting on every push

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -86,15 +86,6 @@ worker.webHookHandler = async function(message, context) {
     });
     if (graphConfig.tasks.length) {
       let graph = await context.scheduler.createTaskGraph(slugid.nice(), graphConfig);
-      // On pushes, leave a comment on the commit
-      if (message.payload.details['event.type'] == 'push') {
-        await github.addCommitComment(
-          context.github,
-          message.payload.organization,
-          message.payload.repository,
-          message.payload.details['event.head.sha'],
-          'TaskCluster-GitHub: ' + INSPECTOR_URL + graph.status.taskGraphId);
-      }
     } else {
       debug('graphConfig compiled with zero tasks: skipping');
     }


### PR DESCRIPTION
This makes tc-github a bit more verbose than we would like. If we'd like, we can go ahead and make this configurable rather than deleting it.

Removing this will make it so that it will be hard to find a graph for a given push you make, but if the task is indexed, you can find it there no problem.
