### PR TITLE
Port to task-groups

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -23,7 +23,7 @@ tasks:
           - push
     payload:
       maxRunTime: 3600
-      image: "node:5"
+      image: "node:6"
       env:
         DEBUG: "* -babel* -mocha* -nock* -express* -body-parser* -morgan -eslint* -follow-redirects"
       features:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -9,6 +9,7 @@ tasks:
     workerType: "{{ taskcluster.docker.workerType }}"
     scopes:
       - "secrets:get:repo:github.com/taskcluster/taskcluster-github*"
+      - "assume:project:taskcluster:github"
     routes:
       - "notify.email.{{event.head.user.email}}.on-any"
       - "notify.irc-channel.#taskcluster-notifications.on-failed"
@@ -26,6 +27,7 @@ tasks:
       image: "node:6"
       env:
         DEBUG: "* -babel* -mocha* -nock* -express* -body-parser* -morgan -eslint* -follow-redirects"
+        QUEUE_BASE_URL: 'taskcluster/queue/v1'
       features:
         taskclusterProxy: true
       command:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
   - CXX=g++-4.8
 node_js:
-- '5'
+- '6'
 cache:
   directories:
     - node_modules

--- a/config.yml
+++ b/config.yml
@@ -21,6 +21,10 @@ defaults:
   webhook:
     secret: !env WEBHOOK_SECRET
 
+  intree:
+    provisionerId: !env PROVISIONER_ID
+    workerType: !env WORKER_TYPE
+
   server:
     publicUrl: 'https://github.taskcluster.net'
     port: !env:number PORT
@@ -42,6 +46,11 @@ production:
   app:
     jobQueue: 'jobs'
     statusQueue: 'statuses'
+
+  intree:
+    provisionerId: 'aws-provisioner-v1'
+    workerType: 'github-worker'
+
   server:
     publicUrl: 'https://github.taskcluster.net'
     env: 'production'
@@ -54,11 +63,10 @@ test:
   webhook:
     secret: 'abc123'
 
-  taskcluster:
-    credentials:
-      clientId: 'test-server'
-      accessToken: 'none'
-
   server:
     publicUrl: 'http://localhost:60415'
     port: 60415
+
+  intree:
+    provisionerId: 'dummy-provisioner'
+    workerType: 'dummy-worker'

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,7 @@ defaults:
     credentials:
       clientId: !env TASKCLUSTER_CLIENT_ID
       accessToken: !env TASKCLUSTER_ACCESS_TOKEN
+    queueBaseUrl: !env QUEUE_BASE_URL
 
   github:
     credentials:

--- a/config.yml
+++ b/config.yml
@@ -4,6 +4,7 @@ defaults:
     exchangePrefix: 'v1/'
     jobQueue: null
     statusQueue: null
+    buildTableName: 'TaskclusterGithubBuilds'
 
   taskcluster:
     # TaskCluster credentials for this server, these must have scopes:
@@ -25,6 +26,9 @@ defaults:
   intree:
     provisionerId: !env PROVISIONER_ID
     workerType: !env WORKER_TYPE
+
+  azure:
+    account: !env AZURE_ACCOUNT_NAME
 
   server:
     publicUrl: 'https://github.taskcluster.net'
@@ -63,6 +67,9 @@ production:
 test:
   webhook:
     secret: 'abc123'
+
+  azure:
+    account: 'inMemory'
 
   server:
     publicUrl: 'http://localhost:60415'

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -182,7 +182,7 @@
     },
     "azure-entities": {
       "version": "1.0.3",
-      "from": "azure-entities@>=1.0.2 <2.0.0",
+      "from": "azure-entities@latest",
       "resolved": "https://registry.npmjs.org/azure-entities/-/azure-entities-1.0.3.tgz",
       "dependencies": {
         "asap": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/taskcluster/taskcluster-github.git"
   },
   "dependencies": {
+    "azure-entities": "^1.0.3",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",
     "babel-runtime": "^6.6.1",

--- a/schemas/build-list.yml
+++ b/schemas/build-list.yml
@@ -1,0 +1,63 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:        "Builds"
+description: |
+  A paginated list of builds
+type:         object
+properties:
+  continuationToken:
+    type: string
+    description: Passed back from Azure to allow us to page through long result sets.
+  builds:
+    type:         array
+    description: |
+      A simple list of builds.
+    items:
+      type: object
+      properties:
+        organization:
+          type: string
+          minLength: {$const: github-identifier-min-length}
+          maxLength: {$const: github-identifier-max-length}
+          pattern: {$const: github-identifier-pattern}
+          description: Github organization associated with the build.
+        repository:
+          type: string
+          minLength: {$const: github-identifier-min-length}
+          maxLength: {$const: github-identifier-max-length}
+          pattern: {$const: github-identifier-pattern}
+          description: Github repository associated with the build.
+        sha:
+          type: string
+          minLength: 40
+          maxLength: 40
+          description: Github revision associated with the build.
+        state:
+          type: string
+          enum: ['pending', 'success', 'error', 'failure']
+          description: Github status associated with the build.
+        taskGroupId:
+          type: string
+          pattern: {$const: slugid-pattern}
+          description: Taskcluster task-group associated with the build.
+        created:
+          type: string
+          format: date-time
+          description: |
+            The initial creation time of the build. This is when it became pending.
+        updated:
+          type: string
+          format: date-time
+          description: |
+            The last updated of the build. If it is done, this is when it finished.
+      additionalProperties: false
+      required:
+        - organization
+        - repository
+        - sha
+        - state
+        - taskGroupId
+        - created
+        - updated
+additionalProperties: false
+required:
+  - builds

--- a/src/data.js
+++ b/src/data.js
@@ -1,0 +1,21 @@
+let Entity = require('azure-entities');
+
+module.exports = {};
+
+/**
+ * Entity for tracking which task-groups are associated
+ * with which org/repo/sha, etc.
+ *
+ */
+module.exports.Build = Entity.configure({
+  version: 1,
+  partitionKey: Entity.keys.CompositeKey('organization', 'repository', 'sha'),
+  rowKey: Entity.keys.StringKey('taskGroupId'),
+  properties: {
+    organization: Entity.types.String,
+    repository: Entity.types.String,
+    sha: Entity.types.String,
+    taskGroupId: Entity.types.String,
+    status: Entity.types.String,
+  },
+});

--- a/src/data.js
+++ b/src/data.js
@@ -16,6 +16,6 @@ module.exports.Build = Entity.configure({
     repository: Entity.types.String,
     sha: Entity.types.String,
     taskGroupId: Entity.types.String,
-    status: Entity.types.String,
+    state: Entity.types.String,
   },
 });

--- a/src/data.js
+++ b/src/data.js
@@ -17,5 +17,7 @@ module.exports.Build = Entity.configure({
     sha: Entity.types.String,
     taskGroupId: Entity.types.String,
     state: Entity.types.String,
+    created: Entity.types.Date,
+    updated: Entity.types.Date,
   },
 });

--- a/src/data.js
+++ b/src/data.js
@@ -9,8 +9,8 @@ module.exports = {};
  */
 module.exports.Build = Entity.configure({
   version: 1,
-  partitionKey: Entity.keys.CompositeKey('organization', 'repository', 'sha'),
-  rowKey: Entity.keys.StringKey('taskGroupId'),
+  partitionKey: Entity.keys.StringKey('taskGroupId'),
+  rowKey: Entity.keys.ConstantKey('taskGroupId'),
   properties: {
     organization: Entity.types.String,
     repository: Entity.types.String,

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -196,7 +196,8 @@ async function jobHandler(message) {
       schema: 'http://schemas.taskcluster.net/github/v1/taskcluster-github-config.json#',
     });
     if (graphConfig.tasks.length) {
-      let taskGroupId = await createTasksInGroup(context.queue, graphConfig);
+      let taskGroupId = graphConfig.tasks[0].task.taskGroupId;
+      await Promise.all(graphConfig.tasks.map(t => context.queue.createTask(t.taskId, t.task)));
 
       // We used to comment on every commit, but setting the status
       // is a nicer thing to do instead. It contains all of the same
@@ -319,15 +320,4 @@ async function isCollaborator({login, organization, repository, sha, context}) {
     body: 'TaskCluster: ' + msg,
   });
   return false;
-}
-
-async function createTasksInGroup(queue, graphConfig) {
-  let taskGroupId = null;
-  let created = [];
-  for (let task of graphConfig.tasks) {
-    taskGroupId = task.task.taskGroupId;
-    created.push(queue.createTask(task.taskId, task.task));
-  }
-  await Promise.all(created);
-  return taskGroupId;
 }

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -231,6 +231,9 @@ async function jobHandler(message) {
         });
         assert.equal(build.state, 'pending', `State for ${organization}/${repository}@${sha}
           already exists but is set to ${build.state} instead of pending!`);
+        assert.equal(build.organization, organization);
+        assert.equal(build.repository, repository);
+        assert.equal(build.sha, sha);
       });
     } else {
       debug(`intree config for ${organization}/${repository} compiled with zero tasks. Skipping.`);

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -104,9 +104,9 @@ async function statusHandler(message) {
     });
   }
 
-  let build = (await this.context.Builds.scan({
+  let build = await this.context.Builds.load({
     taskGroupId,
-  }, {limit: 1})).entries[0];
+  });
   await build.modify((b) => {
     b.status = status;
   });
@@ -223,9 +223,6 @@ async function jobHandler(message) {
           throw err;
         }
         let build = await this.Builds.load({
-          organization,
-          repository,
-          sha,
           taskGroupId,
         });
         assert.equal(build.status, 'pending', `Status for ${organization}/${repository}@${sha}

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -109,6 +109,7 @@ async function statusHandler(message) {
   });
   await build.modify((b) => {
     b.state = state;
+    b.updated = new Date();
   });
 
   debug(`Attempting to update status for ${build.organization}/${build.repository}@${build.sha} (${state})`);
@@ -212,12 +213,15 @@ async function jobHandler(message) {
         context: 'Taskcluster',
       });
 
+      let now = new Date();
       await context.Builds.create({
         organization,
         repository,
         sha,
         taskGroupId,
         state: 'pending',
+        created: now,
+        updated: now,
       }).catch(async (err) => {
         if (err.code !== 'EntityAlreadyExists') {
           throw err;

--- a/src/intree.js
+++ b/src/intree.js
@@ -5,6 +5,8 @@ let tc = require('taskcluster-client');
 let jparam = require('json-parameterization');
 let _ = require('lodash');
 
+module.exports = {};
+
 /**
  * Attach fields to a compiled taskcluster github config so that
  * it becomes a complete task graph config.
@@ -54,8 +56,8 @@ function completeInTreeConfig(config, payload) {
 };
 
 /**
- * Merges an existing taskcluster github config with a pull request message's
- * payload to generate a full task graph config.
+ * Returns a function that merges an existing taskcluster github config with
+ * a pull request message's payload to generate a full task graph config.
  *  params {
  *    config:             '...', A yaml string
  *    payload:            {},    GitHub WebHook message payload
@@ -63,45 +65,48 @@ function completeInTreeConfig(config, payload) {
  *    schema:             url,   Url to the taskcluster config schema
  *  }
  **/
-module.exports = function({config, payload, validator, schema}) {
-  config = yaml.safeLoad(config);
-  let errors = validator(config, schema);
-  if (errors) {
-    throw new Error(errors);
-  }
-  debug(`intree config for ${payload.organization}/${payload.repository} matches valid schema.`);
+module.exports.setup = function(cfg) {
+  return function({config, payload, validator, schema}) {
+    config = yaml.safeLoad(config);
+    let errors = validator(config, schema);
+    if (errors) {
+      throw new Error(errors);
+    }
+    debug(`intree config for ${payload.organization}/${payload.repository} matches valid schema.`);
 
-  // We need to toss out the config version number; it's the only
-  // field that's not also in graph/task definitions
-  let version = config.version;
-  delete config.version;
+    // We need to toss out the config version number; it's the only
+    // field that's not also in graph/task definitions
+    let version = config.version;
+    delete config.version;
 
-  // Perform parameter substitutions. This happens after verification
-  // because templating may change with schema version, and parameter
-  // functions are used as default values for some fields.
-  config = jparam(config, _.merge(payload.details, {
-    $fromNow: (text) => tc.fromNowJSON(text),
-    organization: payload.organization,
-    repository: payload.repository,
-    'taskcluster.docker.provisionerId': 'aws-provisioner-v1',
-    'taskcluster.docker.workerType': 'github-worker',
-  }));
+    // Perform parameter substitutions. This happens after verification
+    // because templating may change with schema version, and parameter
+    // functions are used as default values for some fields.
+    config = jparam(config, _.merge(payload.details, {
+      $fromNow: (text) => tc.fromNowJSON(text),
+      organization: payload.organization,
+      repository: payload.repository,
+      'taskcluster.docker.provisionerId': cfg.intree.provisionerId,
+      'taskcluster.docker.workerType': cfg.intree.workerType,
+    }));
 
-  // Compile individual tasks, filtering any that are not intended
-  // for the current github event type
-  config.tasks = config.tasks.map((task) => {
-    return {
-      taskId: slugid.nice(),
-      task: task,
-    };
-  }).filter((task) => {
-    // Filter out tasks that aren't associated with the current event
-    // being handled
-    let events = task.task.extra.github.events;
-    let branches = task.task.extra.github.branches;
-    return _.some(events, ev => RegExp(ev).test(payload.details['event.type'])) && (!branches || branches &&
-      _.includes(branches, payload.details['event.base.repo.branch']));
-  });
-  return completeInTreeConfig(config, payload);
+    let taskGroupId = slugid.nice();
+    // Compile individual tasks, filtering any that are not intended
+    // for the current github event type. Append taskGroupId while
+    // we're at it.
+    config.tasks = config.tasks.map((task) => {
+      return {
+        taskId: slugid.nice(),
+        task: _.extend(task, {taskGroupId}),
+      };
+    }).filter((task) => {
+      // Filter out tasks that aren't associated with the current event
+      // being handled
+      let events = task.task.extra.github.events;
+      let branches = task.task.extra.github.branches;
+      return _.some(events, ev => RegExp(ev).test(payload.details['event.type'])) && (!branches || branches &&
+        _.includes(branches, payload.details['event.base.repo.branch']));
+    });
+    return completeInTreeConfig(config, payload);
+  };
 };
-

--- a/src/intree.js
+++ b/src/intree.js
@@ -97,7 +97,7 @@ module.exports.setup = function(cfg) {
     config.tasks = config.tasks.map((task) => {
       return {
         taskId: slugid.nice(),
-        task: _.extend(task, {taskGroupId}),
+        task: _.extend(task, {taskGroupId, schedulerId: 'taskcluster-github'}),
       };
     }).filter((task) => {
       // Filter out tasks that aren't associated with the current event

--- a/src/intree.js
+++ b/src/intree.js
@@ -103,8 +103,8 @@ module.exports.setup = function(cfg) {
       // being handled
       let events = task.task.extra.github.events;
       let branches = task.task.extra.github.branches;
-      return _.some(events, ev => RegExp(ev).test(payload.details['event.type'])) && (!branches || branches &&
-        _.includes(branches, payload.details['event.base.repo.branch']));
+      return _.some(events, ev => payload.details['event.type'].startsWith(_.trimEnd(ev, '*'))) &&
+        (!branches || branches && _.includes(branches, payload.details['event.base.repo.branch']));
     });
 
     // Add common taskGroupId and schedulerId. taskGroupId is always the taskId of the first

--- a/src/main.js
+++ b/src/main.js
@@ -116,7 +116,10 @@ let load = loader({
 
   queue: {
     requires: ['cfg'],
-    setup: ({cfg}) => new taskcluster.Queue(cfg.taskcluster),
+    setup: ({cfg}) => new taskcluster.Queue({
+      baseUrl: cfg.taskcluster.queueBaseUrl,
+      credentials: cfg.taskcluster.credentials,
+    }),
   },
 
   reference: {

--- a/src/main.js
+++ b/src/main.js
@@ -106,9 +106,9 @@ let load = loader({
   },
 
   api: {
-    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher'],
-    setup: ({cfg, monitor, validator, github, publisher}) => api.setup({
-      context:          {publisher, cfg, github},
+    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher', 'Builds'],
+    setup: ({cfg, monitor, validator, github, publisher, Builds}) => api.setup({
+      context:          {publisher, cfg, github, Builds},
       authBaseUrl:      cfg.taskcluster.authBaseUrl,
       publish:          process.env.NODE_ENV === 'production',
       baseUrl:          cfg.server.publicUrl + '/v1',

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -1,23 +1,39 @@
+/**
+ * Tests of endpoints in the api _other than_
+ * the github webhook endpoint which is tested
+ * in webhook_test.js
+ */
 suite('api', () => {
   let helper = require('./helper');
   let assert = require('assert');
 
-  // Check the status code returned from a request containing some test data
-  function statusTest(testName, jsonFile, statusCode) {
-    test(testName, async () => {
-      let response = await helper.jsonHttpRequest('./test/data/webhooks/' + jsonFile);
-      assert.equal(response.statusCode, statusCode);
-      response.connection.destroy();
+  test('builds', async function(done) {
+    await helper.Builds.create({
+      organization: 'abc123',
+      repository: 'def456',
+      sha: '7650871208002a13ba35cf232c0e30d2c3d64783',
+      state: 'pending',
+      taskGroupId: 'biizERCQQwi9ZS_WkCSjXQ',
+      created: new Date(),
+      updated: new Date(),
     });
-  };
-
-  // Good data: should all return 200 responses
-  statusTest('Pull Request Opened', 'webhook.pull_request.open.json', 204);
-  statusTest('Pull Request Closed', 'webhook.pull_request.close.json', 204);
-  statusTest('Push', 'webhook.push.json', 204);
-
-  // Bad data: should all return 400 responses
-  statusTest('Push without secret', 'webhook.push.no_secret.json', 400);
-  statusTest('Unknown Event', 'webhook.unknown_event.json', 400);
-  statusTest('Push with bad secret', 'webhook.push.bad_secret.json', 403);
+    await helper.Builds.create({
+      organization: 'ghi789',
+      repository: 'jkl101112',
+      sha: '8650871208002a13ba35cf232c0e30d2c3d64783',
+      state: 'success',
+      taskGroupId: 'aiizERCQQwi9ZS_WkCSjXQ',
+      created: new Date(),
+      updated: new Date(),
+    });
+    let builds = await helper.github.builds();
+    try {
+      assert.equal(builds.builds.length, 2);
+      assert.equal(builds.builds[0].organization, 'abc123');
+      assert.equal(builds.builds[1].organization, 'ghi789');
+      done();
+    } catch (e) {
+      done(e);
+    }
+  });
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,6 +5,7 @@ let path = require('path');
 let fs = require('fs');
 let _ = require('lodash');
 let api = require('../lib/api');
+let Intree = require('../lib/intree');
 let taskcluster = require('taskcluster-client');
 let mocha = require('mocha');
 let exchanges = require('../lib/exchanges');
@@ -62,6 +63,9 @@ mocha.before(async () => {
   });
 
   webServer = await load('server', {profile: 'test', process: 'test'});
+
+  helper.intree = await load('intree', {profile: 'test', process: 'test'});
+  helper.queue = await load('queue', {profile: 'test', process: 'test'});
 
   // Configure pulse receiver
   helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);

--- a/test/helper.js
+++ b/test/helper.js
@@ -66,6 +66,7 @@ mocha.before(async () => {
 
   helper.intree = await load('intree', {profile: 'test', process: 'test'});
   helper.queue = await load('queue', {profile: 'test', process: 'test'});
+  helper.Builds = await load('Builds', {profile: 'test', process: 'test'});
 
   // Configure pulse receiver
   helper.events = new testing.PulseTestReceiver(cfg.pulse, mocha);
@@ -78,6 +79,17 @@ mocha.before(async () => {
 
   // Configure pulse publisher
   helper.publisher = await load('publisher', {profile: 'test', process: 'test'});
+
+  helper.baseUrl = 'http://localhost:' + webServer.address().port + '/v1';
+  let reference = api.reference({baseUrl: helper.baseUrl});
+  helper.Github = taskcluster.createClient(reference);
+  helper.github = new helper.Github({
+    baseUrl: helper.baseUrl,
+    credentials: {
+      clientId: 'test-client',
+      accessToken: 'none',
+    },
+  });
 });
 
 // Cleanup after tests

--- a/test/intree_test.js
+++ b/test/intree_test.js
@@ -1,9 +1,8 @@
 suite('intree config', () => {
-  let  fs         = require('fs');
-  let  intree     = require('../lib/intree');
-  let  assert     = require('assert');
-  let  _          = require('lodash');
-  let  helper     = require('./helper');
+  let fs = require('fs');
+  let assert = require('assert');
+  let _ = require('lodash');
+  let helper = require('./helper');
 
   /**
    * Test github data, like one would see in a pulse message
@@ -47,7 +46,7 @@ suite('intree config', () => {
       params.config = fs.readFileSync(configPath);
       params.schema = 'http://schemas.taskcluster.net/github/v1/taskcluster-github-config.json#';
       params.validator = helper.validator;
-      let config = intree(params);
+      let config = helper.intree(params);
       for (let key of Object.keys(expected)) {
         assert.deepEqual(_.get(config, key), expected[key]);
       }

--- a/test/webhook_test.js
+++ b/test/webhook_test.js
@@ -1,0 +1,23 @@
+suite('webhook', () => {
+  let helper = require('./helper');
+  let assert = require('assert');
+
+  // Check the status code returned from a request containing some test data
+  function statusTest(testName, jsonFile, statusCode) {
+    test(testName, async () => {
+      let response = await helper.jsonHttpRequest('./test/data/webhooks/' + jsonFile);
+      assert.equal(response.statusCode, statusCode);
+      response.connection.destroy();
+    });
+  };
+
+  // Good data: should all return 200 responses
+  statusTest('Pull Request Opened', 'webhook.pull_request.open.json', 204);
+  statusTest('Pull Request Closed', 'webhook.pull_request.close.json', 204);
+  statusTest('Push', 'webhook.push.json', 204);
+
+  // Bad data: should all return 400 responses
+  statusTest('Push without secret', 'webhook.push.no_secret.json', 400);
+  statusTest('Unknown Event', 'webhook.unknown_event.json', 400);
+  statusTest('Push with bad secret', 'webhook.push.bad_secret.json', 403);
+});

--- a/user-config-example.yml
+++ b/user-config-example.yml
@@ -8,3 +8,7 @@ defaults:
   github:
     credentials:
       token: '...'
+  taskcluster:
+    credentials:
+      clientId: '...'
+      accessToken: '...'


### PR DESCRIPTION
This removes any use of the scheduler in favor of task-groups.

I deployed this for a few minutes just to test and it appears to  work. Examples:
push-inspector: https://tools.taskcluster.net/push-inspector/#/fw6STsCxQ6Cpu1fI7DkNdg/fw6STsCxQ6Cpu1fI7DkNdg?_k=qym78g
PR that used the task-group for testing: https://github.com/TaskClusterRobot/hooks-testing/pull/19
