### PR TITLE
more descriptive error message for mismatched signatures

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -135,7 +135,7 @@ api.declare({
         JSON.stringify(body));
       return compareSignatures(calculatedSignature, xHubSignature);
     })) {
-      return resolve(res, 403, 'Bad Signature');
+      return resolve(res, 403, 'X-hub-signature does not match; bad webhook secret?');
     }
   }
 


### PR DESCRIPTION
A worthwhile fix, but also a way to play with review apps in Heroku.