### PR TITLE
Added event.base.ref, event.base.repo.name, event.base.repo.url, event.base.user.login to push metadata

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -18,14 +18,14 @@ function sanitizeGitHubField(field) {
 // See https://developer.github.com/v3/activity/events/types/#pullrequestevent
 function getPullRequestDetails(eventData) {
   return {
-    'event.base.ref': eventData.pull_request.base.ref,
+    'event.base.ref': 'refs/heads/' + eventData.pull_request.base.ref,
     'event.base.repo.branch': eventData.pull_request.base.ref,
     'event.base.repo.name': eventData.pull_request.base.repo.name,
     'event.base.repo.url': eventData.pull_request.base.repo.clone_url,
     'event.base.sha': eventData.pull_request.base.sha,
     'event.base.user.login': eventData.pull_request.base.user.login,
 
-    'event.head.ref': eventData.pull_request.head.ref,
+    'event.head.ref': 'refs/heads/' + eventData.pull_request.head.ref,
     'event.head.repo.branch': eventData.pull_request.head.ref,
     'event.head.repo.name': eventData.pull_request.head.repo.name,
     'event.head.repo.url': eventData.pull_request.head.repo.clone_url,

--- a/src/api.js
+++ b/src/api.js
@@ -18,22 +18,22 @@ function sanitizeGitHubField(field) {
 // See https://developer.github.com/v3/activity/events/types/#pullrequestevent
 function getPullRequestDetails(eventData) {
   return {
-    'event.type': 'pull_request.' + eventData.action,
-    'event.pullNumber': eventData.number,
-
-    'event.base.user.login': eventData.pull_request.base.user.login,
+    'event.base.ref': eventData.pull_request.base.ref,
+    'event.base.repo.branch': eventData.pull_request.base.ref,
     'event.base.repo.name': eventData.pull_request.base.repo.name,
     'event.base.repo.url': eventData.pull_request.base.repo.clone_url,
     'event.base.sha': eventData.pull_request.base.sha,
-    'event.base.ref': eventData.pull_request.base.ref,
-    'event.base.repo.branch': eventData.pull_request.base.ref,
+    'event.base.user.login': eventData.pull_request.base.user.login,
 
-    'event.head.user.login': eventData.pull_request.head.user.login,
+    'event.head.ref': eventData.pull_request.head.ref,
+    'event.head.repo.branch': eventData.pull_request.head.ref,
     'event.head.repo.name': eventData.pull_request.head.repo.name,
     'event.head.repo.url': eventData.pull_request.head.repo.clone_url,
     'event.head.sha': eventData.pull_request.head.sha,
-    'event.head.ref': eventData.pull_request.head.ref,
-    'event.head.repo.branch': eventData.pull_request.head.ref,
+    'event.head.user.login': eventData.pull_request.head.user.login,
+
+    'event.pullNumber': eventData.number,
+    'event.type': 'pull_request.' + eventData.action,
   };
 };
 
@@ -44,18 +44,20 @@ function getPushDetails(eventData) {
   // to get a branch name
   let branch = ref.split('/').slice(2).join('/');
   return {
-    'event.type': 'push',
-
-    // don't think this is needed (and is perhaps misleading)
+    'event.base.ref': ref,
     'event.base.repo.branch': branch,
+    'event.base.repo.url': eventData.repository.clone_url,
+    'event.base.sha': eventData.before,
+    'event.base.user.login': eventData.sender.login,
 
+    'event.head.ref': ref,
     'event.head.repo.branch': branch,
     'event.head.user.login': eventData.sender.login,
     'event.head.repo.name': eventData.repository.name,
     'event.head.repo.url': eventData.repository.clone_url,
     'event.head.sha': eventData.after,
-    'event.head.ref': ref,
-    'event.base.sha': eventData.before,
+
+    'event.type': 'push',
   };
 };
 

--- a/src/api.js
+++ b/src/api.js
@@ -46,16 +46,17 @@ function getPushDetails(eventData) {
   return {
     'event.base.ref': ref,
     'event.base.repo.branch': branch,
+    'event.base.repo.name': eventData.repository.name,
     'event.base.repo.url': eventData.repository.clone_url,
     'event.base.sha': eventData.before,
     'event.base.user.login': eventData.sender.login,
 
     'event.head.ref': ref,
     'event.head.repo.branch': branch,
-    'event.head.user.login': eventData.sender.login,
     'event.head.repo.name': eventData.repository.name,
     'event.head.repo.url': eventData.repository.clone_url,
     'event.head.sha': eventData.after,
+    'event.head.user.login': eventData.sender.login,
 
     'event.type': 'push',
   };


### PR DESCRIPTION
In #99 I was having the problem that `{{ event.base.user.login }}` was intermittently not getting resolved. Although that is a separate issue, it did highlight that we get different data between push events and pull request events.

For the CI task I was running, I needed to `go get` the go package from the github base repository, and then pull changes in from the github head repository (this [peculiar workflow](http://blog.campoy.cat/2014/03/github-and-go-forking-pull-requests-and.html) is an idiosyncrasy of go development).

For Pull Requests, that worked fine, as I had the metadata for both the base repository, and the head repository. However, if the CI task executes as a consequence of a regular push on a branch, rather than a PR, we run into the problem that we don't have a different base and head repository, so we do not have `{{ event.base.user.login }}` for example.

After thinking about this some more, I realised there were essentially two options:

1) to embed logic into the task, so that at runtime (rather than task creation time) the task could detect if it was a pull request or a push that had caused it to be spawned, and then use the _head_ repository settings for the push task, and continue to use both the _base_ and _head_ repositories for the pull request task.
2) to consider that the merge of a pull request is essentially the same as a push, except that the base branch and the head branch happen to be the same branch. In which case, populating both the _head_ and _base_ repository info for a push event with the same data would mean we have a more generic handling.

This is an implementation of option 2, which I consider to be simpler and more intuitive. For the majority of cases, tasks that have been crafted to work with Pull Requests should just work for Push events too. Now a push can be considered to be _like_ a pull request, but where the source and target branches (head and base) are the same.

Note, this could be considered a mild case of sticking a square block through a round hole .... but for the most part I think it will cause broken tests to magically work, and when not, people still have the freedom to craft tasks at runtime based on [`GITHUB_EVENT`](https://docs.taskcluster.net/manual/integrations/github#pull-request-metadata).

This PR therefore adds:

* `event.base.ref`
* `event.base.repo.name`
* `event.base.repo.url`
* `event.base.user.login`

to push events, and sets the value to the same as

* `event.head.ref`
* `event.head.repo.name`
* `event.head.repo.url`
* `event.head.user.login`

At the same time, I also sorted the entries lexicographically, to make it easier to maintain the lists and compare data between different event types.

Lastly, I've also made the data consistent between pull requests events and push events for `{{ event.base.ref }}` and `{{ event.head.ref }}`. Previously, in push events they were refspecs, and in pull request events they were branch names. Now they are consistently a refspec, and the branch names continue to be provided via `{{ event.base.repo.branch }}` and `{{ event.head.repo.branch }}`.