### PR TITLE
Added debugging messages to debug release

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-let debug = require('debug')('taskcluster-github');
+let debug = require('debug')('taskcluster-github:api');
 let crypto = require('crypto');
 let API = require('taskcluster-lib-api');
 let _ = require('lodash');
@@ -171,6 +171,7 @@ api.declare({
     } else if (eventType == 'ping') {
       return resolve(res, 200, 'Received ping event!');
     } else if (eventType == 'release') {
+      debug('Received release event webhook payload. Processing...');
       msg.organization = sanitizeGitHubField(body.repository.owner.login),
       msg.details = getReleaseDetails(body);
       publisherKey = 'release';
@@ -178,6 +179,7 @@ api.declare({
       return resolve(res, 400, 'No publisher available for X-GitHub-Event: ' + eventType);
     }
   } catch (e) {
+    debug('Error processing webhook payload!');
     e.webhookPayload = body;
     throw e;
   }

--- a/src/exchanges.js
+++ b/src/exchanges.js
@@ -1,6 +1,7 @@
 let Exchanges = require('pulse-publisher');
 let assert = require('assert');
 let _ = require('lodash');
+let debug = require('debug')('taskcluster-github:exchanges');
 
 // Common schema prefix
 let SCHEMA_PREFIX_CONST = 'http://schemas.taskcluster.net/github/v1/';
@@ -47,6 +48,13 @@ let commonRoutingKey = function(options) {
 };
 
 let commonMessageBuilder = function(msg) {
+  msg.version = 1;
+  return msg;
+};
+
+// Temporary function for debugging purposes.
+let releaseMessageBuilder = function(msg) {
+  debug('Received webhook for release. Building message...');
   msg.version = 1;
   return msg;
 };
@@ -110,7 +118,7 @@ exchanges.declare({
   ].join('\n'),
   routingKey:         commonRoutingKey(),
   schema:             SCHEMA_PREFIX_CONST + 'github-release-message.json#',
-  messageBuilder:     commonMessageBuilder,
+  messageBuilder:     releaseMessageBuilder, // to be replaced with commonMessageBuilder
   routingKeyBuilder:  msg => _.pick(msg, 'organization', 'repository'),
   CCBuilder:          () => [],
 });

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,4 +1,4 @@
-let debug = require('debug')('taskcluster-github');
+let debug = require('debug')('taskcluster-github:handlers');
 let taskcluster = require('taskcluster-client');
 let slugid = require('slugid');
 let yaml = require('js-yaml');

--- a/src/intree.js
+++ b/src/intree.js
@@ -1,4 +1,4 @@
-let debug = require('debug')('taskcluster-github');
+let debug = require('debug')('taskcluster-github:intree');
 let yaml = require('js-yaml');
 let slugid = require('slugid');
 let tc = require('taskcluster-client');
@@ -92,6 +92,15 @@ module.exports.setup = function(cfg) {
       'taskcluster.docker.workerType': cfg.intree.workerType,
     }));
 
+    // Temporary loop for debugging purposes
+    config.tasks.forEach(task => {
+      if (task.extra.github.events.some(event => event == 'release')) {
+        debug('Found task for a release event in YML...');
+      } else {
+        debug('No release tasks in this YML!');
+      }
+    });
+
     // Compile individual tasks, filtering any that are not intended
     // for the current github event type. Append taskGroupId while
     // we're at it.
@@ -114,6 +123,11 @@ module.exports.setup = function(cfg) {
     if (config.tasks.length > 0) {
       let taskGroupId = config.tasks[0].taskId;
       config.tasks = config.tasks.map((task) => {
+        // Temporary for debugging purposes
+        if (task.task.extra.github.events.some(event => event == 'release')) {
+          debug(`After filtering, found task for release. Task group id: ${taskGroupId}`);
+        }
+
         return {
           taskId: task.taskId,
           task: _.extend(task.task, {taskGroupId, schedulerId: 'taskcluster-github'}),


### PR DESCRIPTION
Trying to find the reason for intermittent failures of release event handling.

Handlers seem to be nicely equipped with debugging messages, so I focused on server side:

intree.js - check to see if YML is being parsed as expected; catch the taskGroupID for releases.
api.js - check to see if release webhooks arrive and being recognized as such.
exchanges.js - check to see if webhook payload is being parsed.

Also added a bit of clarity so that we instantly could see where the message comes from.