### PR TITLE
fix lint

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -296,13 +296,12 @@ async function jobHandler(message) {
       repo: repository,
       sha,
       body: [
-        '<summary>Submitting the task to TaskCluster failed.',
-          '<details>\n',
-            '```js',
-            errorBody,
-            '```',
-          '\n</details>',
-        '</summary>'
+        '<details>\n',
+        '<summary>Submitting the task to TaskCluster failed.  Details</summary>\n\n',
+        '```js\n',
+        errorBody,
+        '```\n',
+        '</details>',
       ].join('\n'),
     });
     throw e;


### PR DESCRIPTION
Lint requires that all of the strings be aligned to the same column.  Also, the summary tag should be nested inside details.  Example:

<details>
<summary>Submitting the task to TaskCluster failed.  Details</summary>

```js
error
body
here
```
</details>