### PR TITLE
Add a common context to debug messages

### DIFF
--- a/schemas/build-list.yml
+++ b/schemas/build-list.yml
@@ -42,6 +42,11 @@ properties:
         eventType:
           type: string
           description: Type of Github event that triggered the build (i.e. push, pull_request.opened).
+        eventId:
+          type: string
+          description: |
+            The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+          pattern: {$const: github-guid-pattern}
         created:
           type: string
           format: date-time
@@ -59,6 +64,8 @@ properties:
         - sha
         - state
         - taskGroupId
+        - eventType
+        - eventId
         - created
         - updated
 additionalProperties: false

--- a/schemas/constants.yml
+++ b/schemas/constants.yml
@@ -7,6 +7,7 @@
 github-identifier-pattern:     "^([a-zA-Z0-9-_%]*)$"
 github-identifier-min-length:  1
 github-identifier-max-length:  100
+github-guid-pattern: "^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$"
 
 identifier-pattern:     "^([a-zA-Z0-9-_]*)$"
 identifier-min-length:  1

--- a/schemas/github-pull-request-message.yml
+++ b/schemas/github-pull-request-message.yml
@@ -29,6 +29,11 @@ properties:
     description: |
       The GitHub `action` which triggered an event.
     enum: [assigned, unassigned, labeled, unlabeled, opened, edited, closed, reopened, synchronize, review_requested]
+  eventId:
+    type: string
+    description: |
+      The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+    pattern: {$const: github-guid-pattern}
   details:
     type:         object
     description: |
@@ -40,3 +45,4 @@ required:
   - repository
   - action
   - installationId
+  - eventId

--- a/schemas/github-push-message.yml
+++ b/schemas/github-push-message.yml
@@ -25,6 +25,11 @@ properties:
     type:          integer
     minLength:    {$const: github-installation-minimum}
     maxLength:    {$const: github-installation-maximum}
+  eventId:
+    type: string
+    description: |
+      The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+    pattern: {$const: github-guid-pattern}
   details:
     type:         object
     description: |
@@ -35,3 +40,4 @@ required:
   - organization
   - repository
   - installationId
+  - eventId

--- a/schemas/github-release-message.yml
+++ b/schemas/github-release-message.yml
@@ -25,6 +25,11 @@ properties:
     type:          integer
     minimum:    {$const: github-installation-minimum}
     maximum:    {$const: github-installation-maximum}
+  eventId:
+    type: string
+    description: |
+      The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+    pattern: {$const: github-guid-pattern}
   details:
     type:         object
     description: |
@@ -34,3 +39,5 @@ required:
   - version
   - organization
   - repository
+  - installationId
+  - eventId

--- a/src/data.js
+++ b/src/data.js
@@ -55,4 +55,22 @@ module.exports.Build = Entity.configure({
     item.eventType = 'Unknown Event';
     return item;
   },
+}).configure({
+  version: 4,
+  properties: {
+    organization: Entity.types.String,
+    repository: Entity.types.String,
+    sha: Entity.types.String,
+    taskGroupId: Entity.types.String,
+    state: Entity.types.String,
+    created: Entity.types.Date,
+    updated: Entity.types.Date,
+    installationId: Entity.types.Number,
+    eventType: Entity.types.String,
+    eventId: Entity.types.String,
+  },
+  migrate: function(item) {
+    item.Id = 'Unknown';
+    return item;
+  },
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -23,6 +23,7 @@ suite('api', () => {
       updated: new Date(),
       installationId: 1,
       eventType: 'push',
+      eventId: '26370a80-ed65-11e6-8f4c-80082678482d',
     });
     await helper.Builds.create({
       organization: 'ghi789',
@@ -34,6 +35,7 @@ suite('api', () => {
       updated: new Date(),
       installationId: 1,
       eventType: 'push',
+      eventId: '26370a80-ed65-11e6-8f4c-80082678482d',
     });
     await helper.Builds.create({
       organization: 'abc123',
@@ -45,6 +47,7 @@ suite('api', () => {
       updated: new Date(),
       installationId: 1,
       eventType: 'push',
+      eventId: '26370a80-ed65-11e6-8f4c-80082678482d',
     });
     await helper.Builds.create({
       organization: 'abc123',
@@ -56,6 +59,7 @@ suite('api', () => {
       updated: new Date(),
       installationId: 1,
       eventType: 'push',
+      eventId: '26370a80-ed65-11e6-8f4c-80082678482d',
     });
   });
 


### PR DESCRIPTION
This allows us to grep the logs much easier and follow the entire lifetime of an event from start to finish. I think next steps medium-term would be to allow tc-lib-monitor to use the new sentry wrap/context functions so that we can always include this with every report to sentry and also every log line.