### PR TITLE
Clear up discrepancy in owners field

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -33,8 +33,8 @@ function getPullRequestDetails(eventData) {
     'event.head.repo.name': eventData.pull_request.head.repo.name,
     'event.head.repo.url': eventData.pull_request.head.repo.clone_url,
     'event.head.sha': eventData.pull_request.head.sha,
-    'event.head.user.login': eventData.pull_request.head.user.login,
-    'event.head.user.id': eventData.pull_request.head.user.id,
+    'event.head.user.login': eventData.sender.login,
+    'event.head.user.id': eventData.sender.id,
 
     'event.pullNumber': eventData.number,
     'event.type': 'pull_request.' + eventData.action,
@@ -72,8 +72,8 @@ function getReleaseDetails(eventData) {
   return {
     'event.type': 'release',
     'event.base.repo.branch': eventData.release.target_commitish,
-    'event.head.user.login': eventData.release.author.login,
-    'event.head.user.id': eventData.release.author.id,
+    'event.head.user.login': eventData.sender.login,
+    'event.head.user.id': eventData.sender.id,
     'event.version': eventData.release.tag_name,
     'event.name': eventData.release.name,
     'event.head.repo.name': eventData.repository.name,


### PR DESCRIPTION
Fix for #114.

This clears up confusing differences between what that field was on different events. This ends up grabbing the user who did something, which I think is closest to our original intentions.