### PR TITLE
New API endpoint to find out if the integration is set for the given repo

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -5,6 +5,7 @@ defaults:
     jobQueue: null
     statusQueue: null
     buildTableName: 'TaskclusterGithubBuilds'
+    ownersDirectoryTableName: 'TaskclusterIntegrationOwners'
     name: 'taskcluster-github'
     statusContext: 'Taskcluster'
 

--- a/schemas/is-installed-for.yml
+++ b/schemas/is-installed-for.yml
@@ -1,0 +1,13 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:        "isInstalledFor"
+description: |
+  Check if Repository has Integration
+type:         object
+properties:
+  installed:
+    type:         boolean
+    description: |
+      True if integration is installed, False otherwise.
+additionalProperties: false
+required:
+  - installed

--- a/src/data.js
+++ b/src/data.js
@@ -74,3 +74,13 @@ module.exports.Build = Entity.configure({
     return item;
   },
 });
+
+module.exports.OwnersDirectory = Entity.configure({
+  version: 1,
+  partitionKey: Entity.keys.StringKey('owner'),
+  rowKey: Entity.keys.ConstantKey('someConstant'),
+  properties: {
+    installationId: Entity.types.Number,
+    owner: Entity.types.String,
+  },
+});

--- a/src/main.js
+++ b/src/main.js
@@ -96,10 +96,25 @@ let load = loader({
     },
   },
 
+  OwnersDirectory: {
+    requires: ['cfg', 'monitor'],
+    setup: async ({cfg, monitor}) => {
+      var ownersDir = await data.OwnersDirectory.setup({
+        account: cfg.azure.account,
+        table: cfg.app.ownersDirectoryTableName,
+        credentials: cfg.taskcluster.credentials,
+        monitor: monitor.prefix(cfg.app.ownersDirectoryTableName.toLowerCase()),
+      });
+
+      await ownersDir.ensureTable();
+      return ownersDir;
+    },
+  },
+
   api: {
-    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher', 'Builds'],
-    setup: ({cfg, monitor, validator, github, publisher, Builds}) => api.setup({
-      context:          {publisher, cfg, github, Builds, monitor: monitor.prefix('api-context')},
+    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher', 'Builds', 'OwnersDirectory'],
+    setup: ({cfg, monitor, validator, github, publisher, Builds, OwnersDirectory}) => api.setup({
+      context:          {publisher, cfg, github, Builds, OwnersDirectory, monitor: monitor.prefix('api-context')},
       authBaseUrl:      cfg.taskcluster.authBaseUrl,
       publish:          process.env.NODE_ENV === 'production',
       baseUrl:          cfg.server.publicUrl + '/v1',

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -8,9 +8,15 @@ suite('api', () => {
   let assert = require('assert');
   let _ = require('lodash');
 
+  let github = Object.create(null);
+
   suiteSetup(async () => {
     await helper.Builds.scan({}, {
       handler: build => build.remove(),
+    });
+
+    await helper.OwnersDirectory.scan({}, {
+      handler: owner => owner.remove(),
     });
 
     await helper.Builds.create({
@@ -61,6 +67,21 @@ suite('api', () => {
       eventType: 'push',
       eventId: '26370a80-ed65-11e6-8f4c-80082678482d',
     });
+
+    await helper.OwnersDirectory.create({
+      installationId: 9090,
+      owner: 'abc123',
+    });
+
+    await helper.OwnersDirectory.create({
+      installationId: 9091,
+      owner: 'qwerty',
+    });
+  });
+
+  setup(async () => {
+    github = await helper.load('github');
+    github.inst(9090).setRepositories('coolRepo', 'anotherCoolRepo', 'awesomeRepo');
   });
 
   test('all builds', async function() {
@@ -99,5 +120,14 @@ suite('api', () => {
     assert.equal(builds.builds[0].organization, 'abc123');
     assert.equal(builds.builds[0].repository, 'xyz');
     assert.equal(builds.builds[0].sha, 'y650871208002a13ba35cf232c0e30d2c3d64783');
+  });
+
+  test('integration installation', async function() {
+    let result = await helper.github.isInstalledFor('abc123', 'coolRepo');
+    assert.deepEqual(result, {installed: true});
+    result = await helper.github.isInstalledFor('abc123', 'unknownRepo');
+    assert.deepEqual(result, {installed: false});
+    result = await helper.github.isInstalledFor('unknownOwner', 'unknownRepo');
+    assert.deepEqual(result, {installed: false});
   });
 });

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -10,6 +10,7 @@ class FakeGithub {
     this.repo_collaborators = {};
     this.github_users = [];
     this.repo_info = {};
+    this.repositories = [];
 
     const throwError = code => {
       let err = new Error();
@@ -64,6 +65,9 @@ class FakeGithub {
           throwError(404);
         }
       },
+      'integrations.getInstallationRepositories': async() => {
+        return this.repositories;
+      },
     };
 
     const debug = Debug('FakeGithub');
@@ -113,6 +117,12 @@ class FakeGithub {
 
   setUser({id, email}) {
     this.github_users.push({id: id.toString(), email});
+  }
+
+  setRepositories(...repoNames) {
+    this.repositories.push({
+      repositories: [...repoNames].map(repo => {return {name: repo};}),
+    });
   }
 }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -78,6 +78,7 @@ mocha.before(async () => {
   helper.publisher = overwrites.publisher = new FakePublisher();
 
   helper.Builds = await helper.load('Builds', overwrites);
+  helper.OwnersDirectory = await helper.load('OwnersDirectory', overwrites);
   helper.intree = overwrites.intree = await helper.load('intree', overwrites);
   webServer = overwrites.server = await helper.load('server', overwrites);
 


### PR DESCRIPTION
NEW DESCRIPTION:
1. Added another Azure table for storing integration owners and installation IDs, so we could look up an ID for a given owner.
2. Added integration_installation event handler to populate the above table.
3. Added the API endpoint which gets owner name and repo name, looks up installation ID in the above table, and uses it to check if the integration was installed for the given repo (using github API). 
4. Added output schema for the API
5. Added three tests for the thing.