### PR TITLE
TypeError: (c.tasks || []).filter is not a function

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -282,10 +282,9 @@ async function jobHandler(message) {
   // This is a bit of a hack, but is needed for bug 1274077 for now
   try {
     let c = yaml.safeLoad(repoconf);
-    c.tasks = (c.tasks || []).filter((task) => _.has(task, 'extra.github'));
+    c.tasks = (Array.isArray(c.tasks) ? c.tasks : []).filter((task) => _.has(task, 'extra.github'));
     if (c.tasks.length === 0) {
-      debug('Skipping tasks because no task with "extra.github" exists!');
-      debug(`Repository: ${organization}/${repository}`);
+      debug(`Skipping tasks in ${organization}/${repository} because no task with "extra.github" exists!`);
       return;
     }
   } catch (e) {


### PR DESCRIPTION
https://sentry.io/taskcluster/taskcluster-github/issues/202595227/

```
TypeError: (c.tasks || []).filter is not a function
  File "/app/lib/handlers.js", line 241, in Handlers._callee8$
    c.tasks = (c.tasks || []).filter(function (task) {
...
(1 additional frame(s) were not displayed)

TypeError: (c.tasks || []).filter is not a function
```