### PR TITLE
Decode dotted repos more permanently

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -235,8 +235,10 @@ async function jobHandler(message) {
   // We must attempt to convert the sanitized fields back to normal here. 
   // Further discussion of how to deal with this cleanly is in
   // https://github.com/taskcluster/taskcluster-github/issues/52
-  let organization = message.payload.organization.replace(/%/g, '.');
-  let repository = message.payload.repository.replace(/%/g, '.');
+  message.payload.organization = message.payload.organization.replace(/%/g, '.');
+  message.payload.repository = message.payload.repository.replace(/%/g, '.');
+  let organization = message.payload.organization;
+  let repository = message.payload.repository;
   let sha = message.payload.details['event.head.sha'];
   if (!sha) {
     debug('Trying to get commit info in job handler...');

--- a/test/pulse_test.js
+++ b/test/pulse_test.js
@@ -39,7 +39,7 @@ suite('pulse', () => {
       let expected = [{
         exchange: `v1/${params.listenFor}`,
         routingKey: params.routingKey,
-        payload: { 
+        payload: {
           organization: 'TaskClusterRobot',
           details: params.details,
           installationId: 5808,


### PR DESCRIPTION
Without this, `imbstack/imbstack.github.io` becomes `imbstack/imbstack%github%io` in the intree-config parsing stuff. This makes it hard to use scopes you've assigned to your repo if it has dots in it.