### PR TITLE
Bug 1337820: update tests to use fake PulseConnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sinon": "^1.17.6",
     "slugid": "^1.1.0",
     "source-map-support": "^0.4.0",
-    "taskcluster-client": "^1.4.0",
+    "taskcluster-client": "^2.3.0",
     "taskcluster-lib-api": "^3.0.0",
     "taskcluster-lib-app": "^1.0.0",
     "taskcluster-lib-docs": "^3.3.0",

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -25,7 +25,7 @@ suite('handlers', () => {
     handlers.oldCreateTasks = handlers.createTasks;
     handlers.createTasks = sinon.stub();
 
-    await handlers.setup({noConnect: true});
+    await handlers.setup();
 
     // set up the allowPullRequests key
     github.inst(5828).setRepoInfo({
@@ -49,6 +49,9 @@ suite('handlers', () => {
 
         debug(`publishing ${JSON.stringify({user, head, base, eventType})}`);
         const message = {
+          exchange: 'exchange/taskcluster-github/v1/release',
+          routingKey: 'ignored',
+          routes: [],
           payload: {
             organization: 'TaskClusterRobot',
             details: {
@@ -69,7 +72,7 @@ suite('handlers', () => {
           },
         };
 
-        handlers.jobListener.emit('message', message);
+        handlers.jobListener.fakeMessage(message);
       });
     }
 
@@ -294,12 +297,14 @@ suite('handlers', () => {
         debug(`publishing ${JSON.stringify({taskGroupId, exchange})}`);
         const message = {
           exchange,
+          routingKey: 'ignored',
+          routes: [],
           payload: {
             status: {taskGroupId},
           },
         };
 
-        handlers.statusListener.emit('message', message);
+        handlers.statusListener.fakeMessage(message);
       });
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,13 +1466,9 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@1.0.14:
+formidable@1.0.14, formidable@~1.0.14:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.14.tgz#2b3f4c411cbb5fdd695c44843e2a23514a43231a"
-
-formidable@~1.0.14:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
 
 fresh@0.2.4:
   version "0.2.4"
@@ -3068,7 +3064,7 @@ taskcluster-client@0.23.4:
   optionalDependencies:
     sockjs-client "^1.0.3"
 
-taskcluster-client@^1.0.1, taskcluster-client@^1.2.0, taskcluster-client@^1.4.0:
+taskcluster-client@^1.0.1, taskcluster-client@^1.2.0:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-1.6.3.tgz#46e08445b7fcb590d4effb35df3f21bab0bb6da2"
   dependencies:
@@ -3088,6 +3084,23 @@ taskcluster-client@^1.0.1, taskcluster-client@^1.2.0, taskcluster-client@^1.4.0:
 taskcluster-client@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-2.1.0.tgz#d7ab239248fb4319895466e13abdd9d616530474"
+  dependencies:
+    amqplib "^0.5.1"
+    debug "^2.1.3"
+    hawk "^2.3.1"
+    lodash "^3.6.0"
+    promise "^6.1.0"
+    slugid "^1.1.0"
+    superagent "~1.7.0"
+    superagent-hawk "^0.0.6"
+    superagent-promise "^0.2.0"
+    url-join "^0.0.1"
+  optionalDependencies:
+    sockjs-client "^1.0.3"
+
+taskcluster-client@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-client/-/taskcluster-client-2.3.0.tgz#6bb938beccc7d682d7adf14e2a69c57882254797"
   dependencies:
     amqplib "^0.5.1"
     debug "^2.1.3"


### PR DESCRIPTION
This is a relatively small change -- it just looks big because I changed the indentation when I removed `noConnect`.  Instead, we set up the connection as usual, but config.yml says it's a fake connection.  Aside from that, this is basically changing `.emit` to `.fakeMessage` and adding a few fields.