### PR TITLE
Added API to make the badges clickable

### DIFF
--- a/test/api_test.js
+++ b/test/api_test.js
@@ -93,7 +93,10 @@ suite('api', () => {
       owner: 'abc123',
       repo: 'awesomeRepo',
       sha: 'master',
-      info: [{creator: {id: 12345}, state: 'success'}, {creator: {id: 55555}, state: 'success'}],
+      info: [
+        {creator: {id: 12345}, state: 'success'},
+        {creator: {id: 55555}, state: 'success', target_url: 'http://google.com'},
+      ],
     });
     github.inst(9090).setStatuses({
       owner: 'abc123',
@@ -170,6 +173,13 @@ suite('api', () => {
     // new repo (no info yet)
     await request.get('http://localhost:60415/v1/badge/abc123/nonTCGHRepo/master').end((err, res) => {
       err ? console.log(err) : assert.equal(res.headers['content-length'], 7873);
+    });
+  });
+
+  test('link for clickable badges', async function() {
+    // check if the function returns a correct link
+    await request.get('http://localhost:60415/v1/taskLink/abc123/awesomeRepo/master').end((err, res) => {
+      err ? console.log(err) : assert.equal(res.text.includes('<title>Google</title>'), true);
     });
   });
 });

--- a/test/valid-yaml.json
+++ b/test/valid-yaml.json
@@ -34,7 +34,7 @@
         "name": "TaskCluster GitHub Tests",
         "description": "Tests for taskcluster github in production",
         "owner": "{{ event.head.user.email }}",
-		"source": "{{ event.head.repo.url }}"
+		    "source": "{{ event.head.repo.url }}"
       }
     }
   ]


### PR DESCRIPTION
Continued work from #174 

Added the new API, which uses Express's redirect() method to redirect the user to the link contained in the status object returned by GitHub.

My three API functions have some duplicate code, so I put that into two separate functions (I haven't touched the other two APIs here yet - I think I'll better do that in a separate PR later).

I also devised a test for the API. It doesn't test much yet, and it's weird, because I'm not sure where to redirect the darn thing (as of now, I redirect to google.com, but I think it's wrong), so any advice there would be much appreciated!