### PR TITLE
Forgotten suggested changes for #189

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yarn": "0.21.3"
   },
   "devDependencies": {
-    "fs-extra": "^2.0.0"
+    "fs-extra": "^2.0.0",
+    "got": "^6.7.1"
   }
 }

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -95,7 +95,7 @@ suite('api', () => {
       sha: 'master',
       info: [
         {creator: {id: 12345}, state: 'success'},
-        {creator: {id: 55555}, state: 'success', target_url: 'http://google.com'},
+        {creator: {id: 55555}, state: 'success', target_url: 'Wonderland'},
       ],
     });
     github.inst(9090).setStatuses({
@@ -178,8 +178,8 @@ suite('api', () => {
 
   test('link for clickable badges', async function() {
     // check if the function returns a correct link
-    await request.get('http://localhost:60415/v1/taskLink/abc123/awesomeRepo/master').end((err, res) => {
-      err ? console.log(err) : assert.equal(res.text.includes('<title>Google</title>'), true);
+    await request.get('http://localhost:60415/v1/taskLink/abc123/awesomeRepo/master').redirects(0).end((err, res) => {
+      err ? console.log(err) : assert.equal(res.text, 'Found. Redirecting to Wonderland');
     });
   });
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -7,7 +7,7 @@ suite('api', () => {
   let helper = require('./helper');
   let assert = require('assert');
   let _ = require('lodash');
-  let request = require('superagent-promise');
+  let got = require('got');
 
   let github = Object.create(null);
 
@@ -155,31 +155,50 @@ suite('api', () => {
   });
 
   test('build badges', async function() {
+    var res;
+
     // status: failure
-    await request.get('http://localhost:60415/v1/badge/abc123/coolRepo/master').end((err, res) => {
-      err ? console.log(err) : assert.equal(res.headers['content-length'], 8615);
-    });
+    try {
+      res = await got('http://localhost:60415/v1/badge/abc123/coolRepo/master');
+    } catch (e) {
+      console.log(`Test for failure status failed. Error: ${JSON.stringify(e)}`);
+    }
+    assert.equal(res.headers['content-length'], 8615);
 
     // status: success
-    await request.get('http://localhost:60415/v1/badge/abc123/awesomeRepo/master').end((err, res) => {
-      err ? console.log(err) : assert.equal(res.headers['content-length'], 9189);
-    });
+    try {
+      res = await got('http://localhost:60415/v1/badge/abc123/awesomeRepo/master');
+    } catch (e) {
+      console.log(`Test for success status failed. Error: ${JSON.stringify(e)}`);
+    }
+    assert.equal(res.headers['content-length'], 9189);
 
     // error
-    await request.get('http://localhost:60415/v1/badge/abc123/unknownRepo/master').end((err, res) => {
-      err ? console.log(err) : assert.equal(res.headers['content-length'], 4268);
-    });
+    try {
+      res = await got('http://localhost:60415/v1/badge/abc123/unknownRepo/master');
+    } catch (e) {
+      console.log(`Test for error during getting status failed. Error: ${JSON.stringify(e)}`);
+    }
+    assert.equal(res.headers['content-length'], 4268);
 
     // new repo (no info yet)
-    await request.get('http://localhost:60415/v1/badge/abc123/nonTCGHRepo/master').end((err, res) => {
-      err ? console.log(err) : assert.equal(res.headers['content-length'], 7873);
-    });
+    try {
+      res = await got('http://localhost:60415/v1/badge/abc123/nonTCGHRepo/master');
+    } catch (e) {
+      console.log(`Test for new repo with no status failed. Error: ${JSON.stringify(e)}`);
+    }
+    assert.equal(res.headers['content-length'], 7873);
   });
 
   test('link for clickable badges', async function() {
+    var res;
+
     // check if the function returns a correct link
-    await request.get('http://localhost:60415/v1/taskLink/abc123/awesomeRepo/master').redirects(0).end((err, res) => {
-      err ? console.log(err) : assert.equal(res.text, 'Found. Redirecting to Wonderland');
-    });
+    try {
+      res = await got('http://localhost:60415/v1/taskLink/abc123/awesomeRepo/master', {followRedirect: false});
+    } catch (e) {
+      console.log(`Test for redirecting to correct page failed. Error: ${JSON.stringify(e)}`);
+    }
+    assert.equal(res.body, 'Found. Redirecting to Wonderland');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -952,7 +952,7 @@ crc@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.0.0.tgz#d11e97ec44a844e5eb15a74fa2c7875d0aac4b22"
 
-create-error-class@^3.0.1:
+create-error-class@^3.0.0, create-error-class@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
@@ -1098,6 +1098,10 @@ duplexer2@^0.1.4:
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
   dependencies:
     readable-stream "^2.0.2"
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -1538,6 +1542,10 @@ get-stream@^2.0.0:
     object-assign "^4.0.1"
     pinkie-promise "^2.0.0"
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -1610,6 +1618,22 @@ got@^5.0.0:
     readable-stream "^2.0.5"
     timed-out "^3.0.0"
     unzip-response "^1.0.2"
+    url-parse-lax "^1.0.0"
+
+got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
     url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
@@ -3266,6 +3290,10 @@ timed-out@^3.0.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
 
+timed-out@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
@@ -3356,6 +3384,10 @@ unpipe@1.0.0:
 unzip-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
+
+unzip-response@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 url-join@^0.0.1:
   version "0.0.1"


### PR DESCRIPTION
- Corrected description of the API
- Made `this` to be passed explicitly as a `context` parameter instead of binding
- Corrected redirecting in the test
- Introduced new development dependency, `got` library, which is now used in tests instead of `superagent-promise`