### PR TITLE
Bug 1343871 - Supports posting custom status to changesets. r=dustin

### DIFF
--- a/schemas/create-comment.yml
+++ b/schemas/create-comment.yml
@@ -1,0 +1,13 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:        "Create comment"
+description: |
+  Write a new comment on a GitHub Issue or Pull Request.
+  Full specification on [GitHub docs](https://developer.github.com/v3/issues/comments/#create-a-comment)
+type:         object
+properties:
+  body:
+    type: string
+    description: The contents of the comment.
+additionalProperties: false
+required:
+  - body 

--- a/schemas/create-status.yml
+++ b/schemas/create-status.yml
@@ -1,0 +1,23 @@
+$schema:  http://json-schema.org/draft-04/schema#
+title:        "Create status"
+description: |
+  Create a commit status on GitHub.
+  Full specification on [GitHub docs](https://developer.github.com/v3/repos/statuses/#create-a-status)
+type:         object
+properties:
+  state:
+    type: string
+    enum: ['pending', 'success', 'error', 'failure']
+    description: The state of the status.
+  target_url:
+    type: string
+    description: The target URL to associate with this status. This URL will be linked from the GitHub UI to allow users to easily see the 'source' of the Status.
+  description:
+    type: string
+    description: A short description of the status.
+  context:
+    type: string
+    description: A string label to differentiate this status from the status of other systems.
+additionalProperties: false
+required:
+  - state

--- a/src/api.js
+++ b/src/api.js
@@ -433,3 +433,49 @@ api.declare({
   }
   return res.status(404).send();
 });
+
+api.declare({
+  name: 'createStatus',
+  title: 'Post a status against a given changeset',
+  description: [
+    'For a given changeset (SHA) of a repository, this will attach a "commit status"',
+    'on github. These statuses are links displayed next to each revision.',
+    'The status is either OK (green check) or FAILURE (red cross), ',
+    'made of a custom title and link.',
+  ].join('\n'),
+  stability: 'experimental',
+  method: 'post',
+  // route and input (schema) matches github API
+  // https://developer.github.com/v3/repos/statuses/#create-a-status
+  route: '/repository/:owner/:repo/statuses/:sha',
+  input: 'create-status.json',
+  scopes: [['github:create-status:${owner}/${repo}']],
+}, async function(req, res) {
+  // Extract owner, repo and sha from request into variables
+  let {owner, repo, sha} = req.params;
+  // Extract other attributes from POST attributes
+  let {state, target_url, description, context} = req.body;
+
+  let instGithub = await installationAuthenticate(owner, this.OwnersDirectory, this.github);
+
+  if (instGithub) {
+    try {
+      await instGithub.repos.createStatus({
+        owner,
+        repo,
+        sha,
+        state,
+        target_url,
+        description,
+        context: context || 'default',
+      });
+
+      return resolve(res, 200, 'Status created!');
+    } catch (e) {
+      debug(`Error creating status: ${JSON.stringify(e)}`);
+      return res.status(500).send();
+    }
+  }
+
+  return res.status(404).send();
+});

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -236,4 +236,17 @@ suite('api', () => {
     assert.equal(status.description, 'Status title');
     assert.equal(status.context, 'customContext');
   });
+
+  test('pull request comment', async function() {
+    await helper.github.createComment('abc123', 'awesomeRepo', 1, {
+      body: 'Task failed here',
+    });
+
+    let comment = github.inst(9090).getComments({
+      owner: 'abc123',
+      repo: 'awesomeRepo',
+      number: 1,
+    }).pop();
+    assert.equal(comment.body, 'Task failed here');
+  });
 });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -201,4 +201,39 @@ suite('api', () => {
     }
     assert.equal(res.body, 'Found. Redirecting to Wonderland');
   });
+
+  test('simple status creation', async function() {
+    await helper.github.createStatus('abc123', 'awesomeRepo', 'master', {
+      state: 'error',
+    });
+
+    let status = github.inst(9090).getStatuses({
+      owner: 'abc123',
+      repo: 'awesomeRepo',
+      sha: 'master',
+    }).pop();
+    assert.equal(status.state, 'error');
+    assert.equal(status.target_url, undefined);
+    assert.equal(status.description, undefined);
+    assert.equal(status.context, 'default');
+  });
+
+  test('advanced status creation', async function() {
+    await helper.github.createStatus('abc123', 'awesomeRepo', 'master', {
+      state: 'failure',
+      target_url: 'http://test.com',
+      description: 'Status title',
+      context: 'customContext',
+    });
+
+    let status = github.inst(9090).getStatuses({
+      owner: 'abc123',
+      repo: 'awesomeRepo',
+      sha: 'master',
+    }).pop();
+    assert.equal(status.state, 'failure');
+    assert.equal(status.target_url, 'http://test.com');
+    assert.equal(status.description, 'Status title');
+    assert.equal(status.context, 'customContext');
+  });
 });

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -21,7 +21,19 @@ class FakeGithub {
     };
 
     const stubs = {
-      'repos.createStatus': () => {},
+      'repos.createStatus': ({owner, repo, sha, state, target_url, description, context}) => {
+        const key = `${owner}/${repo}@${sha}`;
+        const info = {
+          state,
+          target_url,
+          description,
+          context,
+        };
+        if (!this.statuses[key]) {
+          this.statuses[key] = [];
+        }
+        this.statuses[key].push(info);
+      },
       'repos.createCommitComment': () => {},
       'orgs.checkMembership': async ({org, owner}) => {
         if (this.org_membership[org] && this.org_membership[org].has(owner)) {
@@ -150,6 +162,11 @@ class FakeGithub {
   setStatuses({owner, repo, sha, info}) {
     const key = `${owner}/${repo}@${sha}`;
     this.statuses[key] = info;
+  }
+
+  getStatuses({owner, repo, sha}) {
+    const key = `${owner}/${repo}@${sha}`;
+    return this.statuses[key];
   }
 
   hasNextPage() {

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -13,6 +13,7 @@ class FakeGithub {
     this.repo_info = {};
     this.repositories = {};
     this.statuses = {};
+    this.comments = {};
 
     const throwError = code => {
       let err = new Error();
@@ -33,6 +34,16 @@ class FakeGithub {
           this.statuses[key] = [];
         }
         this.statuses[key].push(info);
+      },
+      'repos.createComment': ({owner, repo, number, body}) => {
+        const key = `${owner}/${repo}@${number}`;
+        const info = {
+          body,
+        };
+        if (!this.comments[key]) {
+          this.comments[key] = [];
+        }
+        this.comments[key].push(info);
       },
       'repos.createCommitComment': () => {},
       'orgs.checkMembership': async ({org, owner}) => {
@@ -167,6 +178,11 @@ class FakeGithub {
   getStatuses({owner, repo, sha}) {
     const key = `${owner}/${repo}@${sha}`;
     return this.statuses[key];
+  }
+
+  getComments({owner, repo, number}) {
+    const key = `${owner}/${repo}@${number}`;
+    return this.comments[key];
   }
 
   hasNextPage() {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1343871

I simply mapped Github API to tc-github:
https://developer.github.com/v3/repos/statuses/#create-a-status

I added a test, but I've no idea if that actually works!
Otherwise I think I just miss a scope check before proceeding with this patch?