### PR TITLE
Revert to github client at 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "debug": "^2.1.3",
     "eslint-config-taskcluster": "^2.0.0",
     "eslint-plugin-taskcluster": "^1.0.2",
-    "github": "9.2.0",
+    "github": "8.2.1",
     "js-yaml": "^3.8.1",
     "json-parameterization": "^0.2.0",
     "jsonwebtoken": "^5.7.0",

--- a/src/api.js
+++ b/src/api.js
@@ -140,7 +140,7 @@ async function installationAuthenticate(owner, OwnersDirectory, github) {
 async function findTCStatus(github, owner, repo, branch, configuration) {
   let taskclusterBot = await github.users.getForUser({user: configuration.app.botName});
   // Statuses is an array of status objects, where we find the relevant status
-  let statuses = await github.repos.getStatuses({owner, repo, sha: branch});
+  let statuses = await github.repos.getStatuses({owner, repo, ref: branch});
   return statuses.find(statusObject => statusObject.creator.id === taskclusterBot.id);
 }
 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -86,13 +86,13 @@ suite('api', () => {
     github.inst(9090).setStatuses({
       owner: 'abc123',
       repo: 'coolRepo',
-      sha: 'master',
+      ref: 'master',
       info: [{creator: {id: 12345}, state: 'success'}, {creator: {id: 55555}, state: 'failure'}],
     });
     github.inst(9090).setStatuses({
       owner: 'abc123',
       repo: 'awesomeRepo',
-      sha: 'master',
+      ref: 'master',
       info: [
         {creator: {id: 12345}, state: 'success'},
         {creator: {id: 55555}, state: 'success', target_url: 'Wonderland'},
@@ -101,7 +101,7 @@ suite('api', () => {
     github.inst(9090).setStatuses({
       owner: 'abc123',
       repo: 'nonTCGHRepo',
-      sha: 'master',
+      ref: 'master',
       info: [{creator: {id: 123345}, state: 'success'}],
     });
     github.inst(9090).setUser({id: 55555, email: 'noreply@github.com', user: 'magicalTCspirit'});
@@ -210,7 +210,7 @@ suite('api', () => {
     let status = github.inst(9090).getStatuses({
       owner: 'abc123',
       repo: 'awesomeRepo',
-      sha: 'master',
+      ref: 'master',
     }).pop();
     assert.equal(status.state, 'error');
     assert.equal(status.target_url, undefined);
@@ -229,7 +229,7 @@ suite('api', () => {
     let status = github.inst(9090).getStatuses({
       owner: 'abc123',
       repo: 'awesomeRepo',
-      sha: 'master',
+      ref: 'master',
     }).pop();
     assert.equal(status.state, 'failure');
     assert.equal(status.target_url, 'http://test.com');

--- a/test/checkStaging.js
+++ b/test/checkStaging.js
@@ -44,7 +44,7 @@ const checkStaging = async () => {
     let statuses = await github.repos.getStatuses({
       owner: 'taskcluster',
       repo: 'taskcluster-github-testing',
-      sha,
+      ref: sha,
     });
 
     let status = _.find(statuses, {context: 'Taskcluster-Staging (push)'});

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -99,8 +99,8 @@ class FakeGithub {
       'integrations.getInstallationRepositories': async () => {
         return this._repositories;
       },
-      'repos.getStatuses': async ({owner, repo, sha}) => {
-        const key = `${owner}/${repo}@${sha}`;
+      'repos.getStatuses': async ({owner, repo, ref}) => {
+        const key = `${owner}/${repo}@${ref}`;
         if (this._statuses[key]) {
           return this._statuses[key];
         } else {
@@ -176,13 +176,13 @@ class FakeGithub {
     this._repositories.total_count = this._repositories.repositories.length;
   }
 
-  setStatuses({owner, repo, sha, info}) {
-    const key = `${owner}/${repo}@${sha}`;
+  setStatuses({owner, repo, ref, info}) {
+    const key = `${owner}/${repo}@${ref}`;
     this._statuses[key] = info;
   }
 
-  getStatuses({owner, repo, sha}) {
-    const key = `${owner}/${repo}@${sha}`;
+  getStatuses({owner, repo, ref}) {
+    const key = `${owner}/${repo}@${ref}`;
     return this._statuses[key];
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,9 +1552,9 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github@9.2.0:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/github/-/github-9.2.0.tgz#8a886dc40dd63636707dcaf99df3df26c59f16fc"
+github@8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/github/-/github-8.2.1.tgz#616b2211fbcd1cc8631669aed67653e62eb53816"
   dependencies:
     follow-redirects "0.0.7"
     https-proxy-agent "^1.0.0"


### PR DESCRIPTION
Due to changes made in mikedeboer/node-github#505, there are lots of methods (supposedly all, but a comment on the PR seems to doubt that) that return results inside a `data` object rather than directly as before. That was proving to be a deeply annoying change to make, so I've rolled back to the version right before that since I don't want to spend anymore time on this.