### PR TITLE
Allow interactions from people who have set non-emails as their email

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/taskcluster/taskcluster-github.git"
   },
   "dependencies": {
+    "ajv": "^5.2.3",
     "azure-entities": "^1.0.3",
     "babel-compile": "^2.0.0",
     "babel-preset-taskcluster": "^3.0.0",

--- a/src/api.js
+++ b/src/api.js
@@ -160,7 +160,7 @@ let api = new API({
     'with code ForbiddenByGithub.',
   ].join('\n'),
   schemaPrefix: 'http://schemas.taskcluster.net/github/v1/',
-  context: ['Builds', 'OwnersDirectory', 'monitor', 'publisher', 'cfg'],
+  context: ['Builds', 'OwnersDirectory', 'monitor', 'publisher', 'cfg', 'ajv'],
   errorCodes: {
     ForbiddenByGithub: 403,
   },
@@ -264,7 +264,8 @@ api.declare({
   // Not all webhook payloads include an e-mail for the user who triggered an event
   let headUser = msg.details['event.head.user.id'].toString();
   let userDetails = await instGithub.users.getById({id: headUser});
-  msg.details['event.head.user.email'] = userDetails.email ||
+  msg.details['event.head.user.email'] = this.ajv.validate({type: 'string', format: 'email'}, userDetails.email) ?
+    userDetails.email :
     msg.details['event.head.user.login'].replace(/\[bot\]$/, '') + '@users.noreply.github.com';
   msg.repository = sanitizeGitHubField(body.repository.name);
   msg.eventId = eventId;

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ let Intree = require('./intree');
 let data = require('./data');
 let _ = require('lodash');
 let Promise = require('bluebird');
+let Ajv = require('ajv');
 let taskcluster = require('taskcluster-client');
 let config = require('typed-env-config');
 let monitor = require('taskcluster-lib-monitor');
@@ -38,6 +39,11 @@ let load = loader({
       prefix: 'github/v1/',
       aws: cfg.aws,
     }),
+  },
+
+  ajv: {
+    requires: [],
+    setup: () => new Ajv(),
   },
 
   docs: {
@@ -112,9 +118,9 @@ let load = loader({
   },
 
   api: {
-    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher', 'Builds', 'OwnersDirectory'],
-    setup: ({cfg, monitor, validator, github, publisher, Builds, OwnersDirectory}) => api.setup({
-      context:          {publisher, cfg, github, Builds, OwnersDirectory, monitor: monitor.prefix('api-context')},
+    requires: ['cfg', 'monitor', 'validator', 'github', 'publisher', 'Builds', 'OwnersDirectory', 'ajv'],
+    setup: ({cfg, monitor, validator, github, publisher, Builds, OwnersDirectory, ajv}) => api.setup({
+      context:          {publisher, cfg, github, Builds, OwnersDirectory, monitor: monitor.prefix('api-context'), ajv},
       authBaseUrl:      cfg.taskcluster.authBaseUrl,
       publish:          process.env.NODE_ENV === 'production',
       baseUrl:          cfg.server.publicUrl + '/v1',

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,15 @@ ajv@^4.0.4, ajv@^4.11.2, ajv@^4.7.0, ajv@^4.8.2, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
+ajv@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.2.3.tgz#c06f598778c44c6b161abafe3466b81ad1814ed2"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^1.0.0"
+    json-schema-traverse "^0.3.0"
+    json-stable-stringify "^1.0.1"
+
 amqplib@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.4.2.tgz#5e4a2a914ccb3125f9cb91f6da07c97aa4cb13a6"
@@ -1377,6 +1386,10 @@ fast-azure-storage@^0.3.7:
   optionalDependencies:
     libxmljs "^0.18.0"
 
+fast-deep-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
@@ -1954,6 +1967,10 @@ json-parameterization@^0.2.0:
   dependencies:
     debug "^2.2.0"
     lodash "^3.10.1"
+
+json-schema-traverse@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema@0.2.3:
   version "0.2.3"


### PR DESCRIPTION
This is not the prettiest fix in the world, but tc-gh is already not very pretty. This should allow people with their github profile emails set to things like "foo[at]bar[dot]com" to use tc-gh.

[Bug 1403537](https://bugzilla.mozilla.org/show_bug.cgi?id=1403537)