### PR TITLE
Bug 1422308 - Taskcluster bot replies to PRs with different subject

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -248,7 +248,7 @@ async function jobHandler(message) {
   let repository = message.payload.repository;
   let sha = message.payload.details['event.head.sha'];
   //console.log('..message passed to jobHandler', message);
-  let number = message.payload.details['event.number'];
+  let number = message.payload.details['event.pullNumber'];
   //console.log('..pr number', number);
   if (!sha) {
     debug('Trying to get commit info in job handler...');

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -51,6 +51,20 @@ class FakeGithub {
         }
         this._comments[key].push(info);
       },
+      'pullRequests.createComment': ({owner, repo, number, body}) => {
+        if (repo === 'no-permission') {
+          throwError(403);
+        }
+        console.log(owner, repo, number, body);
+        const key = `${owner}/${repo}@${number}`;
+        const info = {
+          body,
+        };
+        if (!this._comments[key]) {
+          this._comments[key]=[];
+        }
+        this._comments[key].push(info);
+      },
       'repos.createCommitComment': () => {},
       'orgs.checkMembership': async ({org, username}) => {
         if (this._org_membership[org] && this._org_membership[org].has(username)) {

--- a/test/github-auth.js
+++ b/test/github-auth.js
@@ -55,7 +55,7 @@ class FakeGithub {
         if (repo === 'no-permission') {
           throwError(403);
         }
-        console.log(owner, repo, number, body);
+        //console.log(owner, repo, number, body);
         const key = `${owner}/${repo}@${number}`;
         const info = {
           body,

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -71,6 +71,9 @@ suite('handlers', () => {
             version: 1,
           },
         };
+        if (eventType.startsWith('pull_request.')) {
+          message.payload.details['event.number'] = 36;
+        }
 
         handlers.jobListener.fakeMessage(message);
       });

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -72,7 +72,7 @@ suite('handlers', () => {
           },
         };
         if (eventType.startsWith('pull_request.')) {
-          message.payload.details['event.number'] = 36;
+          message.payload.details['event.pullNumber'] = 36;
         }
 
         handlers.jobListener.fakeMessage(message);

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -214,7 +214,7 @@ suite('handlers', () => {
       let args = github.inst(5828).pullRequests.createComment.args;
       assert.equal(args[0][0].owner, 'TaskClusterRobot');
       assert.equal(args[0][0].repo, 'hooks-testing');
-      assert.equal(args[0][0].number, '36');
+      assert.equal(args[0][0].pullNumber, '36');
       assert(args[0][0].body.indexOf('No TaskCluster jobs started for this pull request') !== -1);
     });
 

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -210,11 +210,11 @@ suite('handlers', () => {
       });
       await simulateJobMessage({user: 'imbstack', eventType: 'pull_request.opened'});
 
-      assert(github.inst(5828).repos.createCommitComment.calledOnce);
-      let args = github.inst(5828).repos.createCommitComment.args;
+      assert(github.inst(5828).pullRequests.createComment.calledOnce);
+      let args = github.inst(5828).pullRequests.createComment.args;
       assert.equal(args[0][0].owner, 'TaskClusterRobot');
       assert.equal(args[0][0].repo, 'hooks-testing');
-      assert.equal(args[0][0].sha, '03e9577bc1ec60f2ff0929d5f1554de36b8f48cf');
+      assert.equal(args[0][0].number, '36');
       assert(args[0][0].body.indexOf('No TaskCluster jobs started for this pull request') !== -1);
     });
 
@@ -234,7 +234,7 @@ suite('handlers', () => {
       await simulateJobMessage({user: 'imbstack', eventType: 'pull_request.opened'});
 
       assert(github.inst(5828).repos.createStatus.callCount === 1, 'Status was not updated!');
-      assert(github.inst(5828).repos.createCommitComment.callCount === 0);
+      assert(github.inst(5828).pullRequests.createComment.callCount === 0);
     });
 
     test('specifying allowPullRequests: collaborators in the default branch disallows public', async function() {
@@ -253,7 +253,7 @@ suite('handlers', () => {
       await simulateJobMessage({user: 'imbstack', eventType: 'pull_request.opened'});
 
       assert(github.inst(5828).repos.createStatus.callCount === 0);
-      assert(github.inst(5828).repos.createCommitComment.callCount === 1);
+      assert(github.inst(5828).pullRequests.createComment.callCount === 1);
     });
 
     test('user name not checked for pushes, so status is created', async function() {


### PR DESCRIPTION
I added a method `pullRequests.createComment` to [tests/github-auth.js](https://github.com/taskcluster/taskcluster-github/pull/222/files#diff-99979e9c6c4c7ef22f28ff0ad50cae77R54) for now and used it to comment on a PR in [src/handlers.js](https://github.com/taskcluster/taskcluster-github/pull/222/files#diff-17e95b0c17bfcf5e5d36214802cc8b06R349) . For this I had to add `event.number` to the mock message for pull requests in [test/handlers_test.js](https://github.com/taskcluster/taskcluster-github/pull/222/files#diff-bc6ee6e86e4196af3b4ce47133f58b91R74).
