### PR TITLE
Report table metrics like other services

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -94,7 +94,7 @@ let load = loader({
         account: cfg.azure.account,
         table: cfg.app.buildTableName,
         credentials: cfg.taskcluster.credentials,
-        monitor: monitor.prefix('data.builds'),
+        monitor: monitor.prefix('table.builds'),
       });
 
       await build.ensureTable();
@@ -109,7 +109,7 @@ let load = loader({
         account: cfg.azure.account,
         table: cfg.app.ownersDirectoryTableName,
         credentials: cfg.taskcluster.credentials,
-        monitor: monitor.prefix('data.ownersdirectory'),
+        monitor: monitor.prefix('table.ownersdirectory'),
       });
 
       await ownersDir.ensureTable();

--- a/src/main.js
+++ b/src/main.js
@@ -94,7 +94,7 @@ let load = loader({
         account: cfg.azure.account,
         table: cfg.app.buildTableName,
         credentials: cfg.taskcluster.credentials,
-        monitor: monitor.prefix(cfg.app.buildTableName.toLowerCase()),
+        monitor: monitor.prefix('data.builds'),
       });
 
       await build.ensureTable();
@@ -109,7 +109,7 @@ let load = loader({
         account: cfg.azure.account,
         table: cfg.app.ownersDirectoryTableName,
         credentials: cfg.taskcluster.credentials,
-        monitor: monitor.prefix(cfg.app.ownersDirectoryTableName.toLowerCase()),
+        monitor: monitor.prefix('data.ownersdirectory'),
       });
 
       await ownersDir.ensureTable();


### PR DESCRIPTION
Using `monitor.prefix('data.builds')` makes a lot of sense, since a different deployment of `taskcluster-github`, should pass a different `project` name to monitor... if it passes the same project name, then it should be the same data in tables, etc... I don't know what the staging site does... but if uses the same data, it should also use the same monitor project name, if it uses different data tables, it shouldn't use the same project name.

In testing we use a different project name, well, we mock monitor... but the concept is reasonable I hope :)