### PR TITLE
Correct Test Title

### DIFF
--- a/test/intree_test.js
+++ b/test/intree_test.js
@@ -85,7 +85,7 @@ suite('intree config', () => {
     });
 
   buildConfigTest(
-    'Pull Event, Single Task Config',
+    'Push Event, Single Task Config',
     configPath + 'taskcluster.single.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push'}}),


### PR DESCRIPTION
This [test](https://github.com/taskcluster/taskcluster-github/blob/08155fffccfc1545e83878c13012cfcacf3285e1/test/intree_test.js#L88) is wrongly titled as `Pull Event, Single Task Config`, whereas the test function is actually for a Push Event