### PR TITLE
Bug 1433506 - Add ability to exclude branches

### DIFF
--- a/docs/taskcluster-yml-v0.md
+++ b/docs/taskcluster-yml-v0.md
@@ -93,12 +93,11 @@ tasks:
       github:
         events:
           - push
-        exclude:
-          branches:
-            - master
+        excludeBranches:
+          - master
 ```
 
-If a branch is present in both, `task.extra.github.branches` is given preference over `task.github.exclude.branches`.
+If a branch is present in both, `task.extra.github.branches` is given preference over `task.extra.github.excludeBranches`.
 Branch filtering doesn't work for releases.
 
 ### Roles

--- a/docs/taskcluster-yml-v0.md
+++ b/docs/taskcluster-yml-v0.md
@@ -83,6 +83,22 @@ tasks:
           - master
 ```
 
+You can even choose to exclude certain branches from your task run. The task will run only if it is not on one of the excluded branches. For example, the task defined below will only run for pushes **not** to the master branch:
+
+```yaml
+version: 0
+tasks:
+  - ...
+    extra:
+      github:
+        events:
+          - push
+        exclude:
+          branches:
+            - master
+```
+
+If a branch is present in both, `task.extra.github.branches` is given preference over `task.github.exclude.branches`.
 Branch filtering doesn't work for releases.
 
 ### Roles

--- a/src/intree.js
+++ b/src/intree.js
@@ -131,13 +131,11 @@ module.exports.setup = function(cfg) {
         let events = task.task.extra.github.events;
         let branches = task.task.extra.github.branches;
         let branch = payload.details['event.base.repo.branch'];
-        excludes = task.task.extra.github.exclude;
-        if (excludes) {
-          excludes = task.task.extra.github.exclude.branches;
-        }
+        let excludeBranches = task.task.extra.github.excludeBranches;
+
         return _.some(events, ev => payload.details['event.type'].startsWith(_.trimEnd(ev, '*'))) &&
-          (!(branches || excludes) || 
-            branches && _.includes(branches, branch) || excludes && !_.includes(excludes, branch) ||
+          (!(branches || excludeBranches) || 
+            branches && _.includes(branches, branch) || excludeBranches && !_.includes(excludeBranches, branch) ||
             payload.details['event.type']==='tag');
       });
 

--- a/src/intree.js
+++ b/src/intree.js
@@ -130,8 +130,14 @@ module.exports.setup = function(cfg) {
 
         let events = task.task.extra.github.events;
         let branches = task.task.extra.github.branches;
+        let branch = payload.details['event.base.repo.branch'];
+        excludes = task.task.extra.github.exclude;
+        if (excludes) {
+          excludes = task.task.extra.github.exclude.branches;
+        }
         return _.some(events, ev => payload.details['event.type'].startsWith(_.trimEnd(ev, '*'))) &&
-          (!branches || branches && _.includes(branches, payload.details['event.base.repo.branch']) ||
+          (!(branches || excludes) || 
+            branches && _.includes(branches, branch) || excludes && !_.includes(excludes, branch) ||
             payload.details['event.type']==='tag');
       });
 

--- a/test/data/configs/taskcluster.single.yml
+++ b/test/data/configs/taskcluster.single.yml
@@ -12,9 +12,8 @@ tasks:
         env: true
         events:
           - push
-        exclude:
-          branches:
-            - master
+        excludeBranches:
+          - master
 
     payload:
       image: "ubuntu:latest"

--- a/test/data/configs/taskcluster.single.yml
+++ b/test/data/configs/taskcluster.single.yml
@@ -12,6 +12,10 @@ tasks:
         env: true
         events:
           - push
+        exclude:
+          branches:
+            - master
+
     payload:
       image: "ubuntu:latest"
       command:

--- a/test/data/configs/taskcluster.single.yml
+++ b/test/data/configs/taskcluster.single.yml
@@ -12,7 +12,10 @@ tasks:
         env: true
         events:
           - push
+        branches:
+          - master
         excludeBranches:
+          - foobar
           - master
 
     payload:

--- a/test/intree_test.js
+++ b/test/intree_test.js
@@ -149,10 +149,22 @@ suite('intree config', () => {
     'Push Event, Single Task Config, Branch Excluded (on branch)',
     configPath + 'taskcluster.single.yml',
     {
-      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
+      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'foobar'}}),
     },
     {
       tasks: [],
+    });
+
+  buildConfigTest(
+    'Push Event, Single Task Config, Branch Exclude is overriden by Include',
+    configPath + 'taskcluster.single.yml',
+    {
+      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
+    },
+    {
+      'tasks[0].task.extra.github.events': ['push'],
+      'metadata.owner': 'test@test.com',
+      scopes: ['assume:repo:github.com/testorg/testrepo:branch:master'],
     });
 
   buildConfigTest(

--- a/test/intree_test.js
+++ b/test/intree_test.js
@@ -146,6 +146,16 @@ suite('intree config', () => {
     });
 
   buildConfigTest(
+    'Push Event, Single Task Config, Branch Excluded (on branch)',
+    configPath + 'taskcluster.single.yml',
+    {
+      payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
+    },
+    {
+      tasks: [],
+    });
+
+  buildConfigTest(
     'Star Pull Config',
     configPath + 'taskcluster.star.yml',
     {


### PR DESCRIPTION
Now, one can exclude branches by putting it under `task.extra.github.exclude.branches`

```yaml
version: 0
tasks:
  - ...
    extra:
      github:
        events:
          - push
        exclude:
          branches:
            - master
```
does not run tasks for pushed to the master branch. 
I went with this schema because it allows to exclude events in the future, while being compatible with the current in use configs.
@imbstack 