### PR TITLE
upgrade to version 8.0.0 of taskcluster-lib-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pulse-publisher": "^3.0.3",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.0",
-    "taskcluster-lib-api": "7.0.1",
+    "taskcluster-lib-api": "8.0.0",
     "taskcluster-lib-app": "^2.0.3",
     "taskcluster-lib-docs": "^4.0.0",
     "taskcluster-lib-loader": "^2.0.0",

--- a/src/api.js
+++ b/src/api.js
@@ -171,7 +171,7 @@ let api = new API({
   ].join('\n'),
   name: 'github',
   schemaPrefix: 'http://schemas.taskcluster.net/github/v1/',
-  context: ['Builds', 'OwnersDirectory', 'monitor', 'publisher', 'cfg', 'ajv'],
+  context: ['Builds', 'OwnersDirectory', 'monitor', 'publisher', 'cfg', 'ajv', 'github'],
   errorCodes: {
     ForbiddenByGithub: 403,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2872,9 +2872,9 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-7.0.1.tgz#7ce01219c2faaba0ec016578241cfdf541a95d89"
+taskcluster-lib-api@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.0.0.tgz#d459870d48134a3fdd14fc1c92b244807d6b7c2b"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
Shifts to version 8.0.0 of taskcluster-lib-api.
The tests will most likely not fail now as I have ran them locally and there weren't any pending tests. The same fix applies everywhere. @djmitche Please review. Thanks :)