### PR TITLE
Bug 1446768 - Only post "No taskcluster jobs.." to a PR once

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,5 +1,6 @@
 version: 0
 allowPullRequests: public
+enableJobsError: true
 metadata:
   name: "TaskCluster GitHub Tests"
   description: "All non-integration tests for taskcluster github"

--- a/schemas/taskcluster-github-config.yml
+++ b/schemas/taskcluster-github-config.yml
@@ -57,6 +57,14 @@ properties:
     enum:
       - public
       - collaborators
+  enableJobsError:
+    description: |
+        Flag for enabling "No Taskcluster jobs started for this pull request" error.  The effective policy is found in this property
+        in the `.taskcluster.yml` file in the repository's default branch. 
+    type: boolean 
+    enum:
+      - true
+      - false
   tasks:
     type:           array
     default:        []

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -7,6 +7,7 @@ let EventEmitter = require('events');
 let _ = require('lodash');
 let Promise = require('bluebird');
 let prAllowed = require('./pr-allowed');
+let jobsErrorEnabled = require('./pr-allowed');
 
 let INSPECTOR_URL = 'https://tools.taskcluster.net/task-group-inspector/#/';
 
@@ -343,7 +344,7 @@ async function jobHandler(message) {
     // Decide if a user has permissions to run tasks.
     let login = message.payload.details['event.head.user.login'];
     try {
-      if (!await prAllowed({login, organization, repository, instGithub, debug, message})) {
+      if (!await prAllowed({login, organization, repository, instGithub, debug, message}) && await jobsErrorEnabled({login, organization, repository, instGithub, debug, message}) ) {
         let body = [
           '<details>\n',
           '<summary>No Taskcluster jobs started for this pull request</summary>\n\n',

--- a/src/pr-allowed.js
+++ b/src/pr-allowed.js
@@ -1,6 +1,7 @@
 let yaml = require('js-yaml');
 
 const DEFAULT_POLICY = 'collaborators';
+const DEFAULT_ERROR_POLICY = true;
 
 async function prAllowed(options) {
   switch (await getRepoPolicy(options)) {
@@ -51,7 +52,7 @@ async function getErrorPolicy({login, organization, repository, instGithub, debu
   }
 
   // consult its `allowPullRequests` field
-  return taskclusterYml['enableJobsError'] || DEFAULT_POLICY;
+  return taskclusterYml['enableJobsError'] || DEFAULT_ERROR_POLICY;
 }
 /**
  * Get the repo's "policy" on pull requests, by fetching .taskcluster.yml from the default

--- a/src/pr-allowed.js
+++ b/src/pr-allowed.js
@@ -15,6 +15,44 @@ async function prAllowed(options) {
   }
 }
 
+async function jobsErrorEnabled(options) {
+  switch (await getErrorPolicy(options)) {
+    case false:
+      return false;
+
+    case true:
+      return true;
+
+    default:
+      return false;
+  }
+}
+
+async function getErrorPolicy({login, organization, repository, instGithub, debug}) {
+  // first, get the repository's default branch
+  let repoInfo = (await instGithub.repos.get({owner: organization, repo: repository})).data;
+  let branch = repoInfo.default_branch;
+
+  // load .taskcluster.yml from that branch
+  let taskclusterYml;
+  try {
+    let content = await instGithub.repos.getContent({
+      owner: organization,
+      repo: repository,
+      path: '.taskcluster.yml',
+      ref: branch,
+    });
+    taskclusterYml = yaml.safeLoad(new Buffer(content.data.content, 'base64').toString());
+  } catch (e) {
+    if (e.code === 404) {
+      return DEFAULT_POLICY;
+    }
+    throw e;
+  }
+
+  // consult its `allowPullRequests` field
+  return taskclusterYml['enableJobsError'] || DEFAULT_POLICY;
+}
 /**
  * Get the repo's "policy" on pull requests, by fetching .taskcluster.yml from the default
  * branch, parsing it, and looking at its `allowPullRequests`.
@@ -67,7 +105,7 @@ async function isCollaborator({login, organization, repository, sha, instGithub,
 }
 
 module.exports = prAllowed;
-
+module.exports = jobsErrorEnabled;
 // for testing..
 module.exports.getRepoPolicy = getRepoPolicy;
 module.exports.isCollaborator = isCollaborator;


### PR DESCRIPTION
I have added a flag that would enable/disable the error message. 
Yet to limit the message display frequency to one when it is enabled.