### PR TITLE
Schema cleanup to help with go code generation

### DIFF
--- a/schemas/build-list.yml
+++ b/schemas/build-list.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:        "Builds"
+title:        "Builds Response"
 description: |
   A paginated list of builds
 type:         object
@@ -12,6 +12,7 @@ properties:
     description: |
       A simple list of builds.
     items:
+      title: Build
       type: object
       properties:
         organization:
@@ -48,7 +49,11 @@ properties:
             The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
           oneOf:
             - pattern: {$const: github-guid-pattern}
-            - pattern: 'Unknown'
+              type: string
+              title: Github GUID
+            - enum: [Unknown]
+              type: string
+              title: Unknown Github GUID
         created:
           type: string
           format: date-time

--- a/schemas/create-comment.yml
+++ b/schemas/create-comment.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:        "Create comment"
+title:        "Create Comment Request"
 description: |
   Write a new comment on a GitHub Issue or Pull Request.
   Full specification on [GitHub docs](https://developer.github.com/v3/issues/comments/#create-a-comment)

--- a/schemas/create-status.yml
+++ b/schemas/create-status.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:        "Create status"
+title:        "Create Status Request"
 description: |
   Create a commit status on GitHub.
   Full specification on [GitHub docs](https://developer.github.com/v3/repos/statuses/#create-a-status)

--- a/schemas/repository.yml
+++ b/schemas/repository.yml
@@ -1,5 +1,5 @@
 $schema:  http://json-schema.org/draft-06/schema#
-title:        "repository"
+title:        "Repository Response"
 description: |
   Any Taskcluster-specific Github repository information.
 type:         object


### PR DESCRIPTION
Hi Brian,

This should clean up the [generated code](https://godoc.org/github.com/taskcluster/taskcluster-client-go/tcgithub) in tcgithub.

I switched from `pattern: Unknown` to `enum: [Unknown]` since the pattern can match a partial line (e.g. is like having `^.*Unknown.*$`) but if that was intended, let me know. The alternative was I could have put `pattern: ^Unknown$` but I figured an enum should require fewer CPU cycles than a regexp match.

Thanks,
Pete