### PR TITLE
Show Markdown correctly in error comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pulse-publisher": "^3.0.3",
     "slugid": "^1.1.0",
     "taskcluster-client": "^3.1.0",
-    "taskcluster-lib-api": "8.0.0",
+    "taskcluster-lib-api": "8.3.0",
     "taskcluster-lib-app": "^2.0.3",
     "taskcluster-lib-docs": "^4.2.2",
     "taskcluster-lib-loader": "^2.0.0",

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -132,10 +132,10 @@ class Handlers {
     }
     let body = [
       '<details>\n',
-      '<summary>Submitting the task to Taskcluster failed. Details</summary>\n\n',
-      '```js\n',
-      errorBody,
-      '```\n',
+      '<summary>Submitting the task to Taskcluster failed. Details</summary>',
+      '',
+      errorBody, // already in Markdown..
+      '',
       '</details>',
     ].join('\n') ;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,9 +2730,9 @@ taskcluster-client@^3.0.3, taskcluster-client@^3.1.0:
     slugid "^1.1.0"
     superagent "~3.8.1"
 
-taskcluster-lib-api@8.0.0:
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.0.0.tgz#d459870d48134a3fdd14fc1c92b244807d6b7c2b"
+taskcluster-lib-api@8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/taskcluster-lib-api/-/taskcluster-lib-api-8.3.0.tgz#ced009510f74d1494e81e7a159c9de5814d80742"
   dependencies:
     ajv "^5.3.0"
     aws-sdk "^2.151.0"


### PR DESCRIPTION
Without this patch, the error looks like:

![screenshot-2018-5-1 bug 1446966 - try this one simple trick to improve your testing quality by djmitche pull request 99](https://user-images.githubusercontent.com/28673/39498539-b4b8a850-4d76-11e8-82e8-3006db6187a3.png)

the issue is that the triple-backticks are put around the Markdown output, causing triple-backticks in the markdown to leave verbatim mode.  And all sorts of madness with emoji.

The taskcluster-lib-api update also avoids the unnecessary backslash in the scope.