### PR TITLE
Adding a new schema for taskcluster.yml v1

### DIFF
--- a/schemas/taskcluster-github-config.v1.yml
+++ b/schemas/taskcluster-github-config.v1.yml
@@ -1,12 +1,12 @@
 $schema:            http://json-schema.org/draft-06/schema#
 title:              ".taskcluster.yml format"
 description: |
- Description of a taskclusterrc.yml file v1, which may be used to generate a taskgraph
+ Description of a taskcluster.yml file v1, which may be used to generate a taskgraph
  and tasks.
 type:               object
 properties:
   version:
-    description:    ".taskcluster.yml version"
+    description:    "Version of the format of this file; must be 1"
     enum:           [1]
     type:           integer
   policy:
@@ -25,7 +25,7 @@ properties:
     items:
         title:              "Task definition template"
         description: |
-          Definition of a task that can be scheduled
+          Definition of a task that can be scheduled. Rendered with JSON-e
         type:               object
         additionalProperties: true
 additionalProperties: false

--- a/schemas/taskcluster-github-config.v1.yml
+++ b/schemas/taskcluster-github-config.v1.yml
@@ -1,0 +1,36 @@
+$schema:            http://json-schema.org/draft-07/schema#
+title:              ".taskcluster.yml format"
+description: |
+ Description of a taskclusterrc.yml file v1, which may be used to generate a taskgraph
+ and tasks.
+type:               object
+properties:
+  version:
+    description:    ".taskcluster.yml version"
+    enum:           [1]
+    type:           integer
+  policy:
+    pullRequests:
+      description: |
+          Policy for creating tasks for pull requests.  The effective policy is found in this property
+          in the `.taskcluster.yml` file in the repository's default branch.  See the documentation for
+          detailed definition of the options.
+      type: string
+      enum:
+        - public
+        - collaborators
+  tasks:
+    type:           array
+    default:        []
+    items:
+        title:              "Task Definition"
+        description: |
+          Definition of a task that can be scheduled
+        type:               object
+        properties:
+          created:          {$eval: created}
+          deadline:         {$eval: deadline}
+        additionalProperties: true
+additionalProperties: false
+required:
+  - version

--- a/schemas/taskcluster-github-config.v1.yml
+++ b/schemas/taskcluster-github-config.v1.yml
@@ -1,4 +1,4 @@
-$schema:            http://json-schema.org/draft-07/schema#
+$schema:            http://json-schema.org/draft-06/schema#
 title:              ".taskcluster.yml format"
 description: |
  Description of a taskclusterrc.yml file v1, which may be used to generate a taskgraph

--- a/schemas/taskcluster-github-config.v1.yml
+++ b/schemas/taskcluster-github-config.v1.yml
@@ -23,13 +23,10 @@ properties:
     type:           array
     default:        []
     items:
-        title:              "Task Definition"
+        title:              "Task definition template"
         description: |
           Definition of a task that can be scheduled
         type:               object
-        properties:
-          created:          {$eval: created}
-          deadline:         {$eval: deadline}
         additionalProperties: true
 additionalProperties: false
 required:

--- a/schemas/taskcluster-github-config.yml
+++ b/schemas/taskcluster-github-config.yml
@@ -1,7 +1,7 @@
 $schema:            http://json-schema.org/draft-06/schema#
 title:              ".taskcluster.yml format"
 description: |
- Description of a taskclusterrc.yml file v0, which may be used to generate a taskgraph
+ Description of a taskcluster.yml file v0, which may be used to generate a taskgraph
  and tasks.
 type:               object
 properties:

--- a/schemas/taskcluster-github-config.yml
+++ b/schemas/taskcluster-github-config.yml
@@ -1,7 +1,7 @@
 $schema:            http://json-schema.org/draft-06/schema#
 title:              ".taskcluster.yml format"
 description: |
- Description of a taskclusterrc.yml file, which may be used to generate a taskgraph
+ Description of a taskclusterrc.yml file v0, which may be used to generate a taskgraph
  and tasks.
 type:               object
 properties:


### PR DESCRIPTION
As a part of the JSON-e-fication project, I think I need to add a new schema to validate new `taskcluster.yml`s v1. After finishing (or preliminary finishing) the documentation, I began implementing. TDD is my technique of choice here, but it seems to me I need the schema to be _up there_ somewhere (I am having trouble reading it from a nearby directory). The tests, I imagine, should validate the YAMLs.

My understanding is, in order to get a schema _up there_, I need to add a yaml file to that effect to the `schemas` dir.

So, the new schema for your consideration!