### PR TITLE
Choose validation schema depending on version

### DIFF
--- a/test/intree_test.js
+++ b/test/intree_test.js
@@ -5,7 +5,7 @@ const helper = require('./helper');
 const libUrls = require('taskcluster-lib-urls');
 const jsone = require('json-e');
 
-suite('intree config, v0', function() {
+suite('intree config', function() {
   let intree;
 
   suiteSetup(async function() {
@@ -87,7 +87,7 @@ suite('intree config, v0', function() {
   let configPath = 'test/data/configs/';
 
   buildConfigTest(
-    'Single Task Config',
+    'Single Task Config, v0',
     configPath + 'taskcluster.single.v0.yml',
     {
       payload:    buildMessage(),
@@ -98,7 +98,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Push Event, Single Task Config',
+    'Push Event, Single Task Config, v0',
     configPath + 'taskcluster.single.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push'}}),
@@ -110,7 +110,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Push Event (Push Task + Pull Task + Release Task)',
+    'Push Event (Push Task + Pull Task + Release Task), v0',
     configPath + 'taskcluster.push_pull_release.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push'}}),
@@ -123,7 +123,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Pull Event (Push Task + Pull Task + Release Task)',
+    'Pull Event (Push Task + Pull Task + Release Task), v0',
     configPath + 'taskcluster.push_pull_release.v0.yml',
     {
       payload:    buildMessage(),
@@ -136,7 +136,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Limited (on branch)',
+    'Push Event, Single Task Config, Branch Limited (on branch), v0',
     configPath + 'taskcluster.branchlimited.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
@@ -149,7 +149,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Limited (off branch)',
+    'Push Event, Single Task Config, Branch Limited (off branch), v0',
     configPath + 'taskcluster.branchlimited.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'foobar'}}),
@@ -159,7 +159,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Excluded (on branch)',
+    'Push Event, Single Task Config, Branch Excluded (on branch), v0',
     configPath + 'taskcluster.exclude.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'foobar'}}),
@@ -169,7 +169,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Pull Request Event, Single Task Config, Branch Excluded (on branch)',
+    'Pull Request Event, Single Task Config, Branch Excluded (on branch), v0',
     configPath + 'taskcluster.pull_with_exclude.yml',
     {
       payload:    buildMessage({details: {'event.type': 'pull_request.opened', 'event.base.repo.branch': 'master'}}),
@@ -179,7 +179,7 @@ suite('intree config, v0', function() {
     1);
 
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Exclude and Include errors',
+    'Push Event, Single Task Config, Branch Exclude and Include errors, v0',
     configPath + 'taskcluster.exclude-error.yml',
     {
       payload:    buildMessage({details: {'event.type': 'push', 'event.base.repo.branch': 'master'}}),
@@ -190,7 +190,7 @@ suite('intree config, v0', function() {
     'should-error');
 
   buildConfigTest(
-    'Star Pull Config',
+    'Star Pull Config, v0',
     configPath + 'taskcluster.star.yml',
     {
       payload:    buildMessage(),
@@ -201,7 +201,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Release Event, Single Task Config',
+    'Release Event, Single Task Config, v0',
     configPath + 'taskcluster.release_single.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'release'}}),
@@ -213,7 +213,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Release Event (Push Task + Pull Task + Release Task)',
+    'Release Event (Push Task + Pull Task + Release Task), v0',
     configPath + 'taskcluster.push_pull_release.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'release'}}),
@@ -225,7 +225,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'No extra or extra.github generates an empty config',
+    'No extra or extra.github generates an empty config, v0',
     configPath + 'taskcluster.non-github.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'release'}}),
@@ -234,7 +234,7 @@ suite('intree config, v0', function() {
     0);
 
   buildConfigTest(
-    'Unicode branch names are not allowed',
+    'Unicode branch names are not allowed, v0',
     configPath + 'taskcluster.single.v0.yml',
     {
       payload: buildMessage({details: {'event.base.repo.branch': '🌱', 'event.type': 'push'}}),
@@ -244,7 +244,7 @@ suite('intree config, v0', function() {
     true);
 
   buildConfigTest(
-    'Tag Event, Single Task Config',
+    'Tag Event, Single Task Config, v0',
     configPath + 'taskcluster.tag_single.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'tag', 'event.head.tag': 'v1.0.2'}}),
@@ -256,7 +256,7 @@ suite('intree config, v0', function() {
     });
 
   buildConfigTest(
-    'Tag Event, Single Task Config, Branch Limited (off branch)',
+    'Tag Event, Single Task Config, Branch Limited (off branch), v0',
     configPath + 'taskcluster.tag.branchlimited.v0.yml',
     {
       payload:    buildMessage({details: {'event.type': 'tag', 'event.head.tag': 'v1.0.2'}}),
@@ -266,96 +266,9 @@ suite('intree config, v0', function() {
       'metadata.owner': 'test@test.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:tag:v1.0.2'],
     });
-});
 
-suite('intree config, v1', () => {
-  let intree;
-  let fs = require('fs');
-  let assert = require('assert');
-  let _ = require('lodash');
-
-  suiteSetup(async function() {
-    helper.load.save();
-    await helper.load('cfg');
-    helper.load.cfg('taskcluster.rootUrl', libUrls.testRootUrl());
-    intree = await helper.load('intree');
-  });
-
-  suiteTeardown(function() {
-    helper.load.restore();
-  });
-  
-  /**
-     * Test github data, like one would see in a pulse message
-     * after a pull request
-     **/
-  function buildMessage(params) {
-    let defaultMessage = {
-      organization: 'testorg',
-      repository:   'testrepo',
-      details: {
-        'event.pullNumber': 'eventData.number',
-        'event.type': 'pull_request.opened',
-        'event.base.user.login': 'eventData.pull_request.base.user.login',
-        'event.base.repo.name': 'eventData.pull_request.base.repo.name',
-        'event.base.repo.url': 'eventData.pull_request.base.repo.clone_url',
-        'event.base.repo.branch': 'default_branch',
-        'event.base.sha': 'eventData.pull_request.base.sha',
-        'event.base.ref': 'eventData.pull_request.base.ref',
-        'event.head.user.login': 'eventData.pull_request.head.user.login',
-        'event.head.repo.name': 'eventData.pull_request.head.repo.name',
-        'event.head.repo.url': 'eventData.pull_request.head.repo.clone_url',
-        'event.head.repo.branch': 'eventData.pull_request.head.default_branch',
-        'event.head.sha': 'eventData.pull_request.head.sha',
-        'event.head.ref': 'eventData.pull_request.head.ref',
-        'event.head.user.email': 'test@test.com',
-      },
-    };
-    return _.merge(defaultMessage, params);
-  };
-  
-  /**
-     * Make sure that data merges properly when building configs
-     * testName:    '', A label for the current test case
-     * configPath:  '', Path to a taskclusterConfig file
-     * params:      {
-     *                payload:    {}, WebHook message payload
-     *                validator:  {}, A taskcluster.base validator
-     *              }
-     * count:       number of tasks to expect
-     * expected:    {}, keys=>values expected to exist in the compiled config
-     * shouldError: if you want intree to throw an exception, set this to true
-     **/
-  let buildConfigTest = function(testName, configPath, params, expected, count=-1, shouldError=false) {
-    test(testName, async () => {
-      params.config = fs.readFileSync(configPath);
-      params.schema = libUrls.schema(libUrls.testRootUrl(), 'github', 'v1/taskcluster-github-config.v1.yml');
-      params.validator = helper.validator;
-      let config;
-      try {
-        config = intree(params);
-      } catch (e) {
-        if (shouldError) {
-          return;
-        }
-        throw e;
-      }
-      if (shouldError) {
-        throw new Error('This intree call should have failed!');
-      }
-      if (count > 0) {
-        assert.equal(config.tasks.length, count);
-      }
-      for (let key of Object.keys(expected)) {
-        assert.deepEqual(_.get(config, key), expected[key]);
-      }
-    });
-  };
-  
-  let configPath = 'test/data/configs/';
-  
   buildConfigTest(
-    'Push Event, Single Task Config',
+    'Push Event, Single Task Config, v1',
     configPath + 'taskcluster.single.v1.yml',
     {
       payload:    buildMessage({
@@ -370,9 +283,26 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'https://github.com/TaskClusterRobot/hooks-testing',
       scopes: ['assume:repo:github.com/testorg/testrepo:branch:default_branch'],
     });
-  
+
   buildConfigTest(
-    'Push Event (Push Task + Pull Task + Release Task)',
+    'Push Event, Single Task Config, v1',
+    configPath + 'taskcluster.single.v1.yml',
+    {
+      payload:    buildMessage({
+        details: {'event.type': 'push'},
+        body: require('./data/webhooks/webhook.push.json').body,
+        tasks_for: 'github-push',
+        branch: 'master',
+      }),
+    },
+    {
+      'tasks[0].task.metadata.owner': '', // private email
+      'tasks[0].task.metadata.source': 'https://github.com/TaskClusterRobot/hooks-testing',
+      scopes: ['assume:repo:github.com/testorg/testrepo:branch:default_branch'],
+    });
+    
+  buildConfigTest(
+    'Push Event (Push Task + Pull Task + Release Task), v1',
     configPath + 'taskcluster.push_pull_release.v1.yml',
     {
       payload:    buildMessage({
@@ -387,9 +317,9 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:branch:default_branch'],
     });
-  
+    
   buildConfigTest(
-    'Pull Event (Push Task + Pull Task + Release Task)',
+    'Pull Event (Push Task + Pull Task + Release Task), v1',
     configPath + 'taskcluster.push_pull_release.v1.yml',
     {
       payload:    buildMessage({
@@ -403,9 +333,9 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:pull-request'],
     });
-  
+    
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Limited (on branch)',
+    'Push Event, Single Task Config, Branch Limited (on branch), v1',
     configPath + 'taskcluster.branchlimited.v1.yml',
     {
       payload:    buildMessage({
@@ -420,9 +350,9 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:branch:master'],
     });
-  
+    
   buildConfigTest(
-    'Push Event, Single Task Config, Branch Limited (off branch)',
+    'Push Event, Single Task Config, Branch Limited (off branch), v1',
     configPath + 'taskcluster.branchlimited.v1.yml',
     {
       payload:    buildMessage({
@@ -435,9 +365,9 @@ suite('intree config, v1', () => {
     {
       tasks: [],
     });
-  
+    
   buildConfigTest(
-    'Release Event, Single Task Config',
+    'Release Event, Single Task Config, v1',
     configPath + 'taskcluster.release_single.v1.yml',
     {
       payload:    buildMessage({
@@ -452,9 +382,9 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:release'],
     });
-  
+    
   buildConfigTest(
-    'Release Event (Push Task + Pull Task + Release Task)',
+    'Release Event (Push Task + Pull Task + Release Task), v1',
     configPath + 'taskcluster.push_pull_release.v1.yml',
     {
       payload:    buildMessage({
@@ -469,9 +399,9 @@ suite('intree config, v1', () => {
       'tasks[0].task.metadata.source': 'http://mrrrgn.com',
       scopes: ['assume:repo:github.com/testorg/testrepo:release'],
     });
-  
+    
   buildConfigTest(
-    'Unicode branch names are not allowed',
+    'Unicode branch names are not allowed, v1',
     configPath + 'taskcluster.single.v1.yml',
     {
       payload: buildMessage({
@@ -484,9 +414,9 @@ suite('intree config, v1', () => {
     {},
     0,
     true);
-  
+    
   buildConfigTest(
-    'Tag Event, Single Task Config',
+    'Tag Event, Single Task Config, v1',
     configPath + 'taskcluster.tag_single.v1.yml',
     {
       payload:    buildMessage({


### PR DESCRIPTION
To fix [this]( https://github.com/taskcluster/taskcluster-github/commit/610c4e5db8908ac400eabc5381702fb0f7de2a3a#commitcomment-29424780), I split validation path for the two versions as well. I decided not to touch the `lib-validation` - I'm not sure how it's used elsewhere. In the future, when we ditch the `v0`, this should be an easy refactor to remove the schemas, the choice, and make `handlers` pass the `v1` schema URL into `intree`.