### PR TITLE
Scope mess error message should contain some hint how to fix it

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -125,6 +125,7 @@ class Handlers {
       '',
       errorBody, // already in Markdown..
       '',
+      'Try using the role editor at tools.taskcluster.net/auth/roles to correct these problems.',
       '</details>',
     ].join('\n') ;
 
@@ -239,7 +240,7 @@ async function jobHandler(message) {
   // Authenticating as installation.
   let instGithub = await context.github.getInstallationGithub(message.payload.installationId);
 
-  // We must attempt to convert the sanitized fields back to normal here. 
+  // We must attempt to convert the sanitized fields back to normal here.
   // Further discussion of how to deal with this cleanly is in
   // https://github.com/taskcluster/taskcluster-github/issues/52
   message.payload.organization = message.payload.organization.replace(/%/g, '.');


### PR DESCRIPTION
I asked Dustin and he explained how to use https://tools.taskcluster.net/auth/roles to debug this kind of thing. 

I don't care much at all about the wording, format, placement, etc of the message, just that a small hint is somewhere in the error.