### PR TITLE
Start using v1 .taskcluster.yml

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,59 +1,55 @@
-version: 0
-allowPullRequests: public
+version: 1
+policy:
+  pullRequests: public
 tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    extra:
-      github:
-        env: true
-        events:
-          - pull_request.opened
-          - pull_request.synchronize
-          - pull_request.reopened
-    scopes:
-      - secrets:get:project/taskcluster/testing/taskcluster-github
-    payload:
-      maxRunTime: 3600
-      image: "node:8"
-      env:
-        DEBUG: "* -babel* -mocha* -nock* -express* -body-parser* -morgan -eslint* -follow-redirects"
-        NO_TEST_SKIP: true
-      features:
-        taskclusterProxy: true
-      command:
-        - "/bin/bash"
-        - "-lc"
-        - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && yarn global add node-gyp && yarn && yarn test"
-    metadata:
-      name: "TaskCluster GitHub Tests"
-      description: "All non-integration tests"
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "{{ taskcluster.docker.workerType }}"
-    extra:
-      github:
-        env: true
-        events:
-          - push
-        branches:
-          - master
-    scopes:
-      - secrets:get:project/taskcluster/testing/taskcluster-github
-    payload:
-      maxRunTime: 3600
-      image: "node:8"
-      env:
-        DEBUG: "* -babel* -mocha* -nock* -express* -body-parser* -morgan -eslint* -follow-redirects"
-        NO_TEST_SKIP: true
-      features:
-        taskclusterProxy: true
-      command:
-        - "/bin/bash"
-        - "-lc"
-        - "git clone {{event.head.repo.url}} repo && cd repo && git checkout {{event.head.sha}} && yarn global add node-gyp && yarn && yarn test"
-    metadata:
-      name: "TaskCluster GitHub Tests"
-      description: "All non-integration tests"
-      owner: "{{ event.head.user.email }}"
-      source: "{{ event.head.repo.url }}"
+  - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
+    then:
+      taskId: {$eval: as_slugid("pr_task")}
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      provisionerId: aws-provisioner-v1
+      workerType: github-worker
+      scopes:
+        - secrets:get:project/taskcluster/testing/taskcluster-github
+      payload:
+        maxRunTime: 600
+        image: "node:8"
+        env:
+          DEBUG: "* -mocha* -nock* -express* -body-parser* -eslint*"
+        features:
+          taskclusterProxy: true
+        command:
+          - "/bin/bash"
+          - "-lc"
+          - "git clone ${event.pull_request.head.repo.git_url} repo && cd repo && git checkout ${event.pull_request.head.sha} && yarn && yarn test"
+      metadata:
+        name: "Taskcluster GitHub Tests"
+        description: "All tests"
+        owner: ${event.pull_request.user.login}@users.noreply.github.com
+        source: ${event.repository.url}
+  - $if: 'tasks_for == "github-push"'
+    then:
+      taskId: {$eval: as_slugid("push_task")}
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      provisionerId: aws-provisioner-v1
+      workerType: github-worker
+      scopes:
+        - secrets:get:project/taskcluster/testing/taskcluster-github
+      payload:
+        maxRunTime: 600
+        image: "node:8"
+        env:
+          DEBUG: "* -mocha* -nock* -express* -body-parser* -eslint*"
+          NO_TEST_SKIP: true
+        features:
+          taskclusterProxy: true
+        command:
+          - "/bin/bash"
+          - "-lc"
+          - "git clone ${event.repository.url} repo && cd repo && git checkout ${event.after} && yarn && yarn test"
+      metadata:
+        name: "Taskcluster GitHub Tests"
+        description: "All tests"
+        owner: ${event.pusher.name}@users.noreply.github.com
+        source: ${event.repository.url}

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -292,11 +292,6 @@ async function jobHandler(message) {
   // This is a bit of a hack, but is needed for bug 1274077 for now
   try {
     let c = yaml.safeLoad(repoconf);
-    c.tasks = (Array.isArray(c.tasks) ? c.tasks : []).filter((task) => _.has(task, 'extra.github'));
-    if (c.tasks.length === 0) {
-      debug(`Skipping tasks in ${organization}/${repository} because no task with "extra.github" exists!`);
-      return;
-    }
   } catch (e) {
     if (e.name === 'YAMLException') {
       return await this.createExceptionComment({instGithub, organization, repository, sha, error: e, pullNumber});

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const fs = require('fs');
 const _ = require('lodash');
+const slugid = require('slugid');
 const builder = require('../src/api');
 const Intree = require('../src/intree');
 const taskcluster = require('taskcluster-client');
@@ -88,6 +89,14 @@ exports.withEntities = (mock, skipping) => {
     if (skipping()) {
       return;
     }
+
+    // Need to generate these each time so that pushes and PRs can run at the same time
+    // Maybe at some point we should cook up a real solution to this.
+    const tableVersion = slugid.nice().replace(/[_-]/g, '');
+    exports.buildsTableName = `TaskclusterGithubBuildsV${tableVersion}`;
+    exports.ownersTableName = `TaskclusterIntegrationOwnersV${tableVersion}`;
+    exports.load.cfg('app.buildsTableName', exports.buildsTableName);
+    exports.load.cfg('app.ownersDirectoryTableName', exports.ownersTableName);
 
     if (mock) {
       const cfg = await exports.load('cfg');


### PR DESCRIPTION
This just switches out our own use of v0 for v1! Slight tweak needed to get it to work.

I have deployed `master` back to production so this won't work for now.