### PR TITLE
Clarify event payload

### DIFF
--- a/docs/taskcluster-yml-v1.md
+++ b/docs/taskcluster-yml-v1.md
@@ -50,7 +50,7 @@ The `tasks` property in the YAML file is rendered using [JSON-e](https://github.
 * `tasks_for` - defines the type of event, one of `github-push`,
   `github-pull-request` or `github-release`.
 
-* `event` - the raw Github event; see
+* `event` - the raw Github Webhook event; see
   * [PushEvent](https://developer.github.com/v3/activity/events/types/#pushevent)
   * [PullRequestEvent](https://developer.github.com/v3/activity/events/types/#pullrequestevent)
   * [ReleaseEvent](https://developer.github.com/v3/activity/events/types/#releaseevent)


### PR DESCRIPTION
In version 3 of the GitHub API, the payload of the "Events API" differs
from that of the "Webhook" API. This is discussed in the description of
"PushEvent" [1]:

> Note: The webhook payload example following the table differs
> significantly from the Events API payload described in the table.
> Among other differences, the webhook payload includes both sender and
> pusher objects. Sender and pusher are the same user who initiated the
> push event, but the sender object contains more detail.

Clarify this in the description of the rendering context.

https://developer.github.com/v3/activity/events/types/#pushevent