### PR TITLE
Don't log the github token to the console

### DIFF
--- a/src/github-auth.js
+++ b/src/github-auth.js
@@ -40,7 +40,6 @@ module.exports = async ({cfg}) => {
       try {
         gh.authenticate({type: 'token', token: instaToken.token});
         debug(`Authenticated as installation: ${inst_id}`);
-        console.log(`token: ${instaToken.token}`);
       } catch (e) {
         debug('Authentication as integration failed!');
         throw e;


### PR DESCRIPTION
We don't want secrets in our logs, as they tend to get copy-pasted.