### PR TITLE
Support the 'policy' property in v1

### DIFF
--- a/src/pr-allowed.js
+++ b/src/pr-allowed.js
@@ -41,8 +41,16 @@ async function getRepoPolicy({login, organization, repository, instGithub, debug
     throw e;
   }
 
-  // consult its `allowPullRequests` field
-  return taskclusterYml['allowPullRequests'] || DEFAULT_POLICY;
+  if (!taskclusterYml.version || taskclusterYml.version == 0) {
+    // consult its `allowPullRequests` field
+    return taskclusterYml['allowPullRequests'] || DEFAULT_POLICY;
+  } else if (taskclusterYml.version == 1) {
+    if (taskclusterYml.policy) {
+      return taskclusterYml.policy.pullRequests || DEFAULT_POLICY;
+    }
+  }
+
+  return DEFAULT_POLICY;
 }
 
 async function isCollaborator({login, organization, repository, sha, instGithub, debug}) {

--- a/test/pr-allowed_test.js
+++ b/test/pr-allowed_test.js
@@ -61,6 +61,54 @@ suite('allowPullRequests', function() {
         debug,
       }), 'maybe');
     });
+
+    test('looks at policy.pullRequests for v1', async function() {
+      github.inst(9999).setTaskclusterYml({
+        owner: 'taskcluster',
+        repo: 'testing',
+        ref: 'development',
+        content: {version: 1, policy: {pullRequests: 'maybe'}},
+      });
+
+      assert.equal(await prAllowed.getRepoPolicy({
+        organization: 'taskcluster',
+        repository: 'testing',
+        instGithub: github.inst(9999),
+        debug,
+      }), 'maybe');
+    });
+
+    test('v1: handles policy without pullRequests property', async function() {
+      github.inst(9999).setTaskclusterYml({
+        owner: 'taskcluster',
+        repo: 'testing',
+        ref: 'development',
+        content: {version: 1, policy: {otherPolicy: 'sure'}},
+      });
+
+      assert.equal(await prAllowed.getRepoPolicy({
+        organization: 'taskcluster',
+        repository: 'testing',
+        instGithub: github.inst(9999),
+        debug,
+      }), 'collaborators');
+    });
+
+    test('v1: handles tc.yml without policy property', async function() {
+      github.inst(9999).setTaskclusterYml({
+        owner: 'taskcluster',
+        repo: 'testing',
+        ref: 'development',
+        content: {version: 1, tasks: []},
+      });
+
+      assert.equal(await prAllowed.getRepoPolicy({
+        organization: 'taskcluster',
+        repository: 'testing',
+        instGithub: github.inst(9999),
+        debug,
+      }), 'collaborators');
+    });
   });
 
   suite('isCollaborator', function() {


### PR DESCRIPTION
Looks like this got forgotten in the v1 setup :)

It explains why PRs are getting errors, like https://github.com/taskcluster/taskcluster-cli/pull/205