### PR TITLE
Enforce taskGroupId to match taskId when 1 task exists

### DIFF
--- a/src/tc-yaml.js
+++ b/src/tc-yaml.js
@@ -233,8 +233,25 @@ class VersionOne extends TcYaml {
       // - if only one task, make these match (making the task appear to be a decision task)
       // - if two or more tasks, make them different (so that the taskgroup has no decision task)
       // of course, this can be overriden by users specifying these values.
-      const defaultTaskGroupId = slugid.nice();
-      let defaultTaskId = config.tasks.length == 1 ? defaultTaskGroupId : slugid.nice();
+      let defaultTaskId;
+      let defaultTaskGroupId;
+      if (config.tasks.length == 1) {
+        let soleTask = config.tasks[0];
+        if (soleTask.taskId && soleTask.taskGroupId) {
+          // Nothing to do. Everything is already defined.
+        } else if (soleTask.taskId) {
+          defaultTaskGroupId = soleTask.taskId;
+        } else if (soleTask.taskGroupId) {
+          defaultTaskId = soleTask.taskGroupId;
+        } else {
+          defaultTaskId = slugid.nice();
+          defaultTaskGroupId = defaultTaskId;
+        }
+      } else {
+        defaultTaskId = slugid.nice();
+        defaultTaskGroupId = slugid.nice();
+      }
+
       config.tasks = config.tasks.map(task => {
         task = _.defaults(task, {taskId: defaultTaskId, taskGroupId: defaultTaskGroupId});
         defaultTaskId = slugid.nice(); // invent a new taskId for the next task

--- a/test/tc-yaml_test.js
+++ b/test/tc-yaml_test.js
@@ -32,6 +32,38 @@ suite('tc-yaml_test.js', function() {
       }]);
     });
 
+    test('compileTasks with one taskId sets taskGroupId', function() {
+      const config = {
+        tasks: [{
+          taskId: 'task-1',
+        }],
+      };
+      tcyaml.compileTasks(config, cfg, {});
+      assume(config.tasks).to.deeply.equal([{
+        taskId: 'task-1',
+        task: {
+          taskGroupId: 'task-1',
+          schedulerId: 'test-sched',
+        },
+      }]);
+    });
+
+    test('compileTasks with taskGroupId and one task sets taskId', function() {
+      const config = {
+        tasks: [{
+          taskGroupId: 'tgid-1',
+        }],
+      };
+      tcyaml.compileTasks(config, cfg, {});
+      assume(config.tasks).to.deeply.equal([{
+        taskId: 'tgid-1',
+        task: {
+          taskGroupId: 'tgid-1',
+          schedulerId: 'test-sched',
+        },
+      }]);
+    });
+
     test('compileTasks with two tasks sets default properties', function() {
       const config = {
         tasks: [{}, {}],


### PR DESCRIPTION
Follows #260 up

[Documentation reads](https://docs.taskcluster.net/docs/reference/integrations/taskcluster-github/docs/taskcluster-yml-v1#result): 

>  If the JSON-e rendering produces only one task, then the default taskGroupId and taskId have the same value

There is a case in the current implementation where this statement is not valid. If you set a `taskId` on the only task defined in `.taskcluster.yml`, then the `taskGroupId` doesn't match the `taskId`.

This patch fixes it.

r? @djmitche  