### PR TITLE
Set trustProxy and forceSSL based on env vars

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -65,10 +65,8 @@ production:
 
   server:
     env: 'production'
-    forceSSL: true
-    # We trust the proxy on heroku, as the SSL end-point provided by heroku
-    # is a proxy, so we have to trust it.
-    trustProxy: true
+    forceSSL: !env:BOOL FORCE_SSL
+    trustProxy: !env:BOOL TRUST_PROXY
 
   taskcluster:
     schedulerId: taskcluster-github


### PR DESCRIPTION
The settings are different in Heroku and in GKE, so they need to be
given by env vars.