### PR TITLE
Bug 1501005 - shut down monitoring when finished syncing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -166,8 +166,8 @@ const load = loader({
   },
 
   syncInstallations: {
-    requires: ['github', 'OwnersDirectory'],
-    setup: async ({github, OwnersDirectory}) => {
+    requires: ['github', 'OwnersDirectory', 'monitor'],
+    setup: async ({github, OwnersDirectory, monitor}) => {
       let gh = await github.getIntegrationGithub();
       let installations = (await gh.apps.getInstallations({})).data;
       await Promise.map(installations, inst => {
@@ -176,6 +176,8 @@ const load = loader({
           owner: inst.account.login,
         }, true);
       });
+      monitor.stopResourceMonitoring();
+      await monitor.flush();
     },
   },
 


### PR DESCRIPTION
This fixes the hangs, which occur because tc-lib-monitor is running on an interval (`setInterval`) and node is sticking around to service that.