### PR TITLE
Small fixes

### DIFF
--- a/src/github-auth.js
+++ b/src/github-auth.js
@@ -15,9 +15,9 @@ module.exports = async ({cfg}) => {
       {algorithm: 'RS256', expiresIn: '1m'},
     );
     try {
-      github.authenticate({type: 'integration', token: inteToken});
+      github.authenticate({type: 'app', token: inteToken});
     } catch (e) {
-      debug('Authentication as integration failed!');
+      debug('Authentication as app failed!');
       throw e;
     }
     return github;
@@ -41,7 +41,7 @@ module.exports = async ({cfg}) => {
         gh.authenticate({type: 'token', token: instaToken.token});
         debug(`Authenticated as installation: ${inst_id}`);
       } catch (e) {
-        debug('Authentication as integration failed!');
+        debug('Authentication as app failed!');
         throw e;
       }
       return gh;

--- a/test/handler_test.js
+++ b/test/handler_test.js
@@ -12,7 +12,7 @@ helper.secrets.mockSuite('handlers', ['taskcluster'], function(mock, skipping) {
   helper.withEntities(mock, skipping);
   helper.withFakeGithub(mock, skipping);
 
-  const URL_PREFIX = 'https://tools.taskcluster.net/task-group-inspector/#/';
+  const URL_PREFIX = 'https://tc-tests.localhost/task-group-inspector/#/';
 
   let github = null;
   let handlers = null;


### PR DESCRIPTION
* Transition from deprecated form of github API to modern
* Something uncovered by me trying to get tc-🐈 work - we have inspector URL hard-coded, so the links to the tasks will be broken everywhere except main cluster.

This is currently being tested by me and tc-🐈