### PR TITLE
Stop referring to old taskcluster.PulseConnection

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -38,7 +38,6 @@ class Handlers {
     this.monitor = monitor;
     this.reference = reference;
     this.intree = intree;
-    this.connection = null;
     this.resultStatusQueueName = resultStatusQueueName;
     this.jobQueueName = jobQueueName;
     this.initialStatusQueueName = initialStatusQueueName;
@@ -58,8 +57,7 @@ class Handlers {
    */
   async setup(options = {}) {
     debug('Setting up handlers...');
-    assert(!this.connection, 'Cannot setup twice!');
-    this.connection = new taskcluster.PulseConnection(this.credentials);
+    assert(!this.jobPq, 'Cannot setup twice!');
 
     // Listen for new jobs created via the api webhook endpoint
     const GithubEvents = taskcluster.createClient(this.reference);
@@ -131,9 +129,14 @@ class Handlers {
 
   async terminate() {
     debug('Terminating handlers...');
-    if (this.connection) {
-      await this.connection.close();
-      this.connection = undefined;
+    if (this.jobPq) {
+      await this.jobPq.stop();
+    }
+    if (this.resultStatusPq) {
+      await this.resultStatusPq.stop();
+    }
+    if (this.initialStatusPq) {
+      await this.initialStatusPq.stop();
     }
   }
 


### PR DESCRIPTION
The `this.connection` property wasn't being used anywhere!  However,
`terminate` was also not stopping the consumers, so this commit includes
a fix to do so.

(Note, I think the checks PR will require addition of a few similar lines to `terminate`)